### PR TITLE
Implement adaptive midpoint (q*) for bidirectional labeling

### DIFF
--- a/include/bgspprc/bucket_graph.h
+++ b/include/bgspprc/bucket_graph.h
@@ -60,6 +60,7 @@ public:
         if (opts_.symmetric) {
             build_arc_lookup();
         }
+        midpoint_initialized_ = false;
     }
 
     /// Update reduced costs (fast, O(1) — just stores the pointer).
@@ -96,6 +97,9 @@ public:
     void set_stage(Stage s) { opts_.stage = s; }
     void set_tolerance(double t) { opts_.tolerance = t; }
     bool enumeration_complete() const { return enum_complete_; }
+
+    void reset_midpoint() { midpoint_initialized_ = false; }
+    double midpoint() const { return midpoint_; }
 
     /// Save best labels for warm starting the next solve.
     /// Keeps the top `fraction` of non-dominated labels by cost.
@@ -794,6 +798,8 @@ private:
             remove_dominated(new_label, actual_bi, dir, labels);
             labels[actual_bi].push_back(new_label);
             ++label_count;
+            if (dir == Direction::Forward) ++fw_label_count_;
+            else ++bw_label_count_;
             return true;
         }
         return false;
@@ -1482,13 +1488,31 @@ private:
 
     // ── Bi-directional solve ──
 
-    double compute_midpoint() const {
+    double get_midpoint() {
+        if (!midpoint_initialized_) {
+            double min_lb = INF, max_ub = -INF;
+            for (int v = 0; v < pv_.n_vertices; ++v) {
+                min_lb = std::min(min_lb, pv_.vertex_lb[0][v]);
+                max_ub = std::max(max_ub, pv_.vertex_ub[0][v]);
+            }
+            midpoint_ = (min_lb + max_ub) / 2.0;
+            midpoint_initialized_ = true;
+        }
+        return midpoint_;
+    }
+
+    void adjust_midpoint() {
+        if (fw_label_count_ == 0 && bw_label_count_ == 0) return;
         double min_lb = INF, max_ub = -INF;
         for (int v = 0; v < pv_.n_vertices; ++v) {
             min_lb = std::min(min_lb, pv_.vertex_lb[0][v]);
             max_ub = std::max(max_ub, pv_.vertex_ub[0][v]);
         }
-        return (min_lb + max_ub) / 2.0;
+        if (fw_label_count_ > 1.2 * bw_label_count_) {
+            midpoint_ += 0.05 * (max_ub - midpoint_);
+        } else if (bw_label_count_ > 1.2 * fw_label_count_) {
+            midpoint_ -= 0.05 * (midpoint_ - min_lb);
+        }
     }
 
     std::vector<Path> solve_bidirectional() {
@@ -1497,6 +1521,8 @@ private:
         reset_label_storage(bw_bucket_labels_);
         reset_c_best();
 
+        fw_label_count_ = 0;
+        bw_label_count_ = 0;
         total_enum_labels_ = 0;
         enum_complete_ = true;
         enum_sink_labels_ = 0;
@@ -1511,7 +1537,7 @@ private:
             }
         }
 
-        double mu = compute_midpoint();
+        double mu = get_midpoint();
 
         // Forward labeling
         auto* src = create_initial_label(Direction::Forward);
@@ -1548,6 +1574,9 @@ private:
             // Symmetric: populate bw_c_best from fw c_best via mirror
             populate_symmetric_bw_c_best();
         }
+
+        if (opts_.stage == Stage::Exact && !opts_.symmetric)
+            adjust_midpoint();
 
         // Collect paths: forward labels that reached sink + concatenations
         auto paths = extract_paths(fw_bucket_labels_);
@@ -1898,6 +1927,12 @@ private:
     bool enum_complete_ = true;
     int enum_sink_labels_ = 0;  // labels that landed in sink buckets
     double fixing_theta_ = INF;  // theta used in last fix_buckets call
+
+    // Adaptive midpoint for bidirectional labeling
+    int fw_label_count_ = 0;
+    int bw_label_count_ = 0;
+    double midpoint_ = 0.0;
+    bool midpoint_initialized_ = false;
 
     LabelPool<Pack> pool_;
     R1CManager r1c_;

--- a/include/bgspprc/solver.h
+++ b/include/bgspprc/solver.h
@@ -74,6 +74,10 @@ public:
     /// Reset all elimination/fixing.
     void reset_elimination() { bg_.reset_elimination(); }
 
+    /// Adaptive midpoint control for bidirectional labeling.
+    void reset_midpoint() { bg_.reset_midpoint(); }
+    double midpoint() const { return bg_.midpoint(); }
+
     /// Set R1C cuts.
     void set_r1c_cuts(std::span<const R1Cut> cuts) { bg_.set_r1c_cuts(cuts); }
 

--- a/tests/test_bucket_graph.cpp
+++ b/tests/test_bucket_graph.cpp
@@ -1759,4 +1759,122 @@ TEST_CASE("Enumerate: theta mismatch warning") {
     bg.solve();  // should not warn
     CHECK(bg.enumeration_complete());
 }
+
+TEST_CASE("Midpoint initializes to average of resource bounds") {
+    SimpleGraph g;
+    // tw_lb all 0, tw_ub all 10 → midpoint = (0+10)/2 = 5
+    BucketGraph<EmptyPack> bg(g.pv, EmptyPack{},
+        {.bucket_steps = {5.0, 1.0}, .tolerance = 1e9, .bidirectional = true});
+    bg.build();
+    bg.solve();
+    CHECK(bg.midpoint() == doctest::Approx(5.0));
+}
+
+TEST_CASE("Midpoint adjusts on forward-heavy imbalance") {
+    // Asymmetric graph: fan-out near source with small time, then a single
+    // arc with large time to sink. Forward creates many labels (one per
+    // intermediate vertex) in the q <= midpoint zone, while backward from
+    // sink crosses the midpoint in one hop and stops extending.
+    //
+    // 0→1,0→2,0→3,0→4 (t=1), 1→5,2→5,3→5,4→5 (t=1), 5→6 (t=8)
+    // TW: [0,10] for all. Midpoint = 5.
+    // Forward: labels at 1,2,3,4 (q=1), 5 (q=2), 6 (q=10) → ~9 labels
+    // Backward: 6→5 lands at q=2 < midpoint → only 1 label inserted
+    // Ratio ~9:1 → triggers 5% shift toward max.
+    int from_arr[9] = {0, 0, 0, 0, 1, 2, 3, 4, 5};
+    int to_arr[9]   = {1, 2, 3, 4, 5, 5, 5, 5, 6};
+    double cost_arr[9] = {1, 2, 3, 4, 1, 1, 1, 1, 1};
+    double time_arr[9] = {1, 1, 1, 1, 1, 1, 1, 1, 8};
+    double tw_lb[7] = {0, 0, 0, 0, 0, 0, 0};
+    double tw_ub[7] = {10, 10, 10, 10, 10, 10, 10};
+
+    const double* arc_res[1] = {time_arr};
+    const double* v_lb[1]    = {tw_lb};
+    const double* v_ub[1]    = {tw_ub};
+
+    ProblemView pv;
+    pv.n_vertices = 7;
+    pv.source = 0;
+    pv.sink = 6;
+    pv.n_arcs = 9;
+    pv.arc_from = from_arr;
+    pv.arc_to = to_arr;
+    pv.arc_base_cost = cost_arr;
+    pv.n_resources = 1;
+    pv.arc_resource = arc_res;
+    pv.vertex_lb = v_lb;
+    pv.vertex_ub = v_ub;
+    pv.n_main_resources = 1;
+
+    BucketGraph<EmptyPack> bg(pv, EmptyPack{},
+        {.bucket_steps = {1.0, 1.0}, .tolerance = 1e9, .bidirectional = true,
+         .stage = Stage::Exact});
+    bg.build();
+
+    bg.solve();
+    double mid1 = bg.midpoint();
+    // First solve: initializes to 5.0, then adjusts upward (fw >> bw)
+    CHECK(mid1 > 5.0);
+
+    bg.solve();
+    double mid2 = bg.midpoint();
+    // Second solve: should shift further upward
+    CHECK(mid2 > mid1);
+}
+
+TEST_CASE("Midpoint resets on build") {
+    LargerGraph g;
+    BucketGraph<EmptyPack> bg(g.pv, EmptyPack{},
+        {.bucket_steps = {5.0, 1.0}, .tolerance = 1e9, .bidirectional = true,
+         .stage = Stage::Exact});
+    bg.build();
+    bg.solve();
+    double mid1 = bg.midpoint();
+    CHECK(mid1 != 0.0);  // should be initialized
+
+    // Rebuild resets midpoint
+    bg.build();
+    bg.solve();
+    double mid2 = bg.midpoint();
+    // After rebuild, midpoint reinitializes to default (same graph → same value)
+    CHECK(mid2 == doctest::Approx(mid1).epsilon(0.1));
+}
+
+TEST_CASE("No midpoint adjustment in heuristic/enumerate stages") {
+    LargerGraph g;
+    BucketGraph<EmptyPack> bg(g.pv, EmptyPack{},
+        {.bucket_steps = {5.0, 1.0}, .tolerance = 1e9, .bidirectional = true,
+         .stage = Stage::Heuristic1});
+    bg.build();
+    bg.solve();
+    double mid_h1 = bg.midpoint();
+    // Solve again — heuristic should not adjust
+    bg.solve();
+    double mid_h2 = bg.midpoint();
+    CHECK(mid_h1 == doctest::Approx(mid_h2));
+}
+
+TEST_CASE("Bidirectional correctness preserved with adaptive midpoint") {
+    LargerGraph g;
+
+    BucketGraph<EmptyPack> mono(g.pv, EmptyPack{},
+        {.bucket_steps = {5.0, 1.0}, .tolerance = 1e9});
+    mono.build();
+    auto mono_paths = mono.solve();
+
+    BucketGraph<EmptyPack> bidir(g.pv, EmptyPack{},
+        {.bucket_steps = {5.0, 1.0}, .tolerance = 1e9, .bidirectional = true,
+         .stage = Stage::Exact});
+    bidir.build();
+    // Solve multiple times to let midpoint adapt
+    auto bidir_paths = bidir.solve();
+    bidir_paths = bidir.solve();
+    bidir_paths = bidir.solve();
+
+    REQUIRE(!mono_paths.empty());
+    REQUIRE(!bidir_paths.empty());
+    CHECK(bidir_paths[0].reduced_cost ==
+          doctest::Approx(mono_paths[0].reduced_cost));
+}
+
 #endif  // !_WIN32


### PR DESCRIPTION
## Summary

- Adaptive bidirectional threshold q* per BucketGraph 2021 §5: after each exact solve, shifts midpoint 5% toward the overloaded direction when forward/backward label counts differ by >20%
- Lazy-initializes to `(min_lb + max_ub) / 2`, persists across solves, resets on `build()`
- Exposes `midpoint()` / `reset_midpoint()` on both BucketGraph and Solver

## Test plan

- [x] Midpoint initializes to average of resource bounds
- [x] Midpoint adjusts on forward-heavy imbalance
- [x] Reset on `build()` reinitializes midpoint
- [x] No adjustment in heuristic/enumerate stages
- [x] Bidirectional correctness preserved (matches mono results)
- [x] All 108 tests pass, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)