### PR TITLE
Relax Heuristic2 dominance, non-disposable resources, symmetric() interface

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,57 @@
+# Implementation plan — gaps vs. papers
+
+## Actionable (SPPRC-layer)
+
+### 1. ~~Heuristic2: relax ng/R1C in dominance~~ ✓ DONE
+**Paper**: VRPSolver 2020 §5.1.3
+**Status**: Done. `dominates()` now skips ng/R1C for both Heuristic1 and
+Heuristic2 stages. Test added.
+
+### 2. Exact completion bounds during elimination
+**Paper**: BucketGraph 2021 §5
+**Status**: Not implemented. For labels extended past q*, exhaustively check if
+a θ-compatible opposite label exists before keeping them. Tighter elimination,
+beyond current bound-based + label-based.
+**Effort**: Medium — requires per-label compatibility scan during elimination.
+
+### 3. ~~Non-disposable resource dominance~~ ✓ DONE
+**Paper**: VRPSolver 2020 §5.1.2
+**Status**: Done. `ProblemView::resource_nondisposable` flag; main resource
+dominance uses equality when set. Test added.
+
+### 4. ~~`symmetric()` interface function~~ ✓ DONE
+**Paper**: Meta-Solver 2026 §4.1
+**Status**: Done. Per-resource `symmetric()` method added to Resource concept.
+NgPathResource=true, StandardResource=false. BucketGraph asserts on mismatch.
+
+## Revisit
+
+### 5. R^cc (cumulative cost) and R^spd (pickup-delivery) resources
+**Paper**: Meta-Solver 2026 §5–6
+**Status**: Not implemented. Application-specific resources that users would
+define via the ResourcePack interface. R^cc is novel (cumulative CVRP), R^spd
+handles simultaneous pickup and delivery.
+**Why revisit**: Validates the ResourcePack interface design — implementing these
+as user-defined resources would confirm the interface is general enough (or
+expose gaps).
+
+### 6. `extendAlongArc` / `extendToVertex` split
+**Paper**: Meta-Solver 2026 §4.1 (functions 3–4)
+**Status**: Deliberately unified into single `extend()`, which is equivalent.
+**Why revisit**: The split enables arc-ending labels which are the natural unit
+for across-arc concatenation. Currently concatenation extends a forward label
+through the across-arc and then checks compatibility — the split would let
+forward labels stop at the arc midpoint naturally. May also matter for resources
+where arc-ending vs vertex-ending state differs (e.g. R^spd).
+
+## Out of scope (BCP-layer)
+
+These are above the SPPRC solver layer:
+
+- RCC separation (VRPSolver §3.6)
+- Branching strategies (VRPSolver §4)
+- Dual price smoothing / stabilization (VRPSolver §5.2)
+- Safe dual bounds (VRPSolver §5.3)
+- Primal heuristics — restricted master, diving with LDS (VRPSolver §5.5)
+- Dynamic ng-set augmentation (VRPSolver §5.2)
+- Rollback procedure — removing cuts when pricing is slow (VRPSolver §5.2)

--- a/include/bgspprc/bucket_graph.h
+++ b/include/bgspprc/bucket_graph.h
@@ -43,9 +43,16 @@ public:
 
     BucketGraph(const ProblemView& pv, Pack pack, Options opts = {})
         : pv_(pv), pack_(std::move(pack)), opts_(opts) {
-        if (opts_.symmetric) opts_.bidirectional = true;
+        if (opts_.symmetric) {
+            opts_.bidirectional = true;
+            if constexpr (Pack::size > 0)
+                assert(pack_.symmetric() &&
+                       "symmetric mode requires all resources to be symmetric");
+        }
         adj_.build(pv_);
         n_main_ = std::min(pv_.n_main_resources, 2);
+        for (int r = 0; r < n_main_; ++r)
+            main_nondisposable_[r] = pv_.resource_nondisposable && pv_.resource_nondisposable[r];
     }
 
     /// Build the bucket graph structure.
@@ -680,15 +687,18 @@ private:
         if (L1->vertex != L2->vertex) return false;
 
         for (int r = 0; r < n_main_; ++r) {
-            if (dir == Direction::Forward) {
+            if (main_nondisposable_[r]) {
+                // Non-disposable: require equality
+                if (std::abs(L1->q[r] - L2->q[r]) > EPS) return false;
+            } else if (dir == Direction::Forward) {
                 if (L1->q[r] > L2->q[r] + EPS) return false;
             } else {
                 if (L1->q[r] < L2->q[r] - EPS) return false;
             }
         }
 
-        // Heuristic1: cost-only dominance (ignore resource states)
-        if (opts_.stage == Stage::Heuristic1) {
+        // Heuristic stages: cost-only dominance (ignore ng/R1C states)
+        if (opts_.stage == Stage::Heuristic1 || opts_.stage == Stage::Heuristic2) {
             return L1->cost <= L2->cost + EPS;
         }
 
@@ -1813,6 +1823,7 @@ private:
     Options opts_;
     Adjacency adj_;
     int n_main_ = 1;
+    std::array<bool, 2> main_nondisposable_ = {false, false};
 
     const double* reduced_costs_ = nullptr;
 

--- a/include/bgspprc/problem_view.h
+++ b/include/bgspprc/problem_view.h
@@ -30,6 +30,11 @@ struct ProblemView {
 
     int n_main_resources = 1;  // 1 or 2 (defines bucket grid dimensions)
 
+    // Per-resource non-disposability: array of n_resources bools.
+    // true = non-disposable (equality required in dominance).
+    // nullptr means all resources are disposable (default).
+    const bool* resource_nondisposable = nullptr;
+
     // Adjacency (caller-built or we build internally)
     // outgoing_arcs[v] = span of arc indices leaving v
     // incoming_arcs[v] = span of arc indices entering v

--- a/include/bgspprc/resource.h
+++ b/include/bgspprc/resource.h
@@ -11,6 +11,7 @@ namespace bgspprc {
 /// Concept for a Meta-Solver resource type.
 ///
 /// Each resource carries per-label state and defines:
+///  - symmetric: whether this resource supports symmetric labeling (§4.1)
 ///  - extend: how state changes along an arc
 ///  - domination_cost: extra cost penalty when L1's state is "worse" than L2's
 ///  - concatenation_cost: cost adjustment when joining forward/backward labels
@@ -19,6 +20,7 @@ concept Resource = requires(const R& r, Direction dir, Symmetry sym,
                             typename R::State s, typename R::State s2,
                             int arc_id, int vertex) {
     typename R::State;
+    { r.symmetric() } -> std::same_as<bool>;
     { r.init_state(dir) } -> std::same_as<typename R::State>;
     { r.extend(dir, s, arc_id) } -> std::same_as<std::pair<typename R::State, double>>;
     { r.domination_cost(dir, vertex, s, s2) } -> std::same_as<double>;
@@ -34,6 +36,13 @@ struct ResourcePack {
     static constexpr std::size_t size = sizeof...(Rs);
 
     explicit ResourcePack(Rs... rs) : resources(std::move(rs)...) {}
+
+    /// True if all resources in the pack support symmetric labeling.
+    bool symmetric() const {
+        return std::apply(
+            [](const auto&... rs) { return (rs.symmetric() && ...); },
+            resources);
+    }
 
     StatesTuple init_states(Direction dir) const {
         return std::apply(

--- a/include/bgspprc/resources/ng_path.h
+++ b/include/bgspprc/resources/ng_path.h
@@ -29,6 +29,9 @@ namespace bgspprc {
 struct NgPathResource {
     using State = uint64_t;
 
+    /// Ng-path resource is always symmetric (Meta-Solver 2026 §4.2.2).
+    bool symmetric() const { return true; }
+
     /// Per-arc precomputed transform data for both directions.
     struct ArcInfo {
         // Forward: extending from→to

--- a/include/bgspprc/resources/standard.h
+++ b/include/bgspprc/resources/standard.h
@@ -24,6 +24,11 @@ namespace bgspprc {
 struct StandardResource {
     using State = double;
 
+    /// Standard resource symmetry depends on arc consumptions and bounds
+    /// (Meta-Solver 2026 §4.2.1). Caller should verify conditions externally;
+    /// conservatively returns false.
+    bool symmetric() const { return false; }
+
     const double* consumption;  // per-arc consumption d_a, size = n_arcs
     const double* lb;           // per-vertex lower bound, size = n_vertices
     const double* ub;           // per-vertex upper bound, size = n_vertices

--- a/include/bgspprc/types.h
+++ b/include/bgspprc/types.h
@@ -11,7 +11,7 @@ enum class Symmetry : uint8_t { Asymmetric, Symmetric };
 
 enum class Stage : uint8_t {
     Heuristic1,  // light dominance, fast
-    Heuristic2,  // full dominance, relaxed pruning
+    Heuristic2,  // cost + resource dominance, ignore ng/R1C
     Fixing,      // arc/bucket fixing with gap
     Exact,       // full exact labeling
     Enumerate    // find all paths within gap

--- a/tests/test_bucket_graph.cpp
+++ b/tests/test_bucket_graph.cpp
@@ -1128,6 +1128,142 @@ TEST_CASE("NgPathResource: prevents revisiting in BucketGraph") {
     }
 }
 
+TEST_CASE("Heuristic2: relaxed ng dominance prunes more aggressively") {
+    // Graph: 0 → 1 via two paths with different intermediate vertices
+    //   0 →(a0) 2 →(a1) 1 →(a2) 3
+    //   0 →(a3) 4 →(a4) 1 →(a2) 3
+    // Both paths reach vertex 1 with same cost and q, but different ng-states.
+    // Heuristic2 ignores ng → labels look identical → one dominates the other.
+    // Exact sees distinct ng-states → neither dominates → both survive.
+    int from[] = {0, 2, 1, 0, 4};
+    int to[]   = {2, 1, 3, 4, 1};
+    double cost[] = {1.0, 1.0, 1.0, 1.0, 1.0};
+    double td[] = {1.0, 1.0, 1.0, 1.0, 1.0};
+
+    double tw_lb[] = {0.0, 0.0, 0.0, 0.0, 0.0};
+    double tw_ub[] = {20.0, 20.0, 20.0, 20.0, 20.0};
+
+    const double* arc_res[] = {td};
+    const double* v_lb[] = {tw_lb};
+    const double* v_ub[] = {tw_ub};
+
+    ProblemView pv;
+    pv.n_vertices = 5;
+    pv.source = 0;
+    pv.sink = 3;
+    pv.n_arcs = 5;
+    pv.arc_from = from;
+    pv.arc_to = to;
+    pv.arc_base_cost = cost;
+    pv.n_resources = 1;
+    pv.arc_resource = arc_res;
+    pv.vertex_lb = v_lb;
+    pv.vertex_ub = v_ub;
+    pv.n_main_resources = 1;
+
+    // Full ng-neighborhoods: every vertex sees every other
+    std::vector<std::vector<int>> neighbors = {
+        {0, 1, 2, 3, 4}, {1, 0, 2, 3, 4}, {2, 0, 1, 3, 4},
+        {3, 0, 1, 2, 4}, {4, 0, 1, 2, 3}
+    };
+    NgPathResource ng(5, 5, from, to, neighbors);
+    using Pack = ResourcePack<NgPathResource>;
+
+    // Heuristic2: cost-only dominance, ng-states ignored
+    BucketGraph<Pack> bg_h2(pv, make_resource_pack(NgPathResource(ng)),
+        {.bucket_steps = {5.0, 1.0}, .tolerance = 1e9,
+         .stage = Stage::Heuristic2});
+    bg_h2.build();
+    auto paths_h2 = bg_h2.solve();
+
+    // Exact: full dominance including ng-states
+    BucketGraph<Pack> bg_ex(pv, make_resource_pack(NgPathResource(ng)),
+        {.bucket_steps = {5.0, 1.0}, .tolerance = 1e9,
+         .stage = Stage::Exact});
+    bg_ex.build();
+    auto paths_ex = bg_ex.solve();
+
+    // Both should find valid paths
+    REQUIRE(!paths_h2.empty());
+    REQUIRE(!paths_ex.empty());
+
+    // Heuristic2 ignores ng-states → more aggressive dominance → fewer paths
+    // Exact preserves labels with distinct ng-states → more paths survive
+    CHECK(paths_ex.size() >= paths_h2.size());
+}
+
+TEST_CASE("Non-disposable resource: equality required in dominance") {
+    // Two paths to vertex 2, same cost, different resource consumption.
+    // 0 →(a0) 1 →(a1) 2 →(a2) 3   (q = 1+1 = 2)
+    // 0 →(a3) 1 →(a4) 2 →(a2) 3   (q = 1+2 = 3)
+    // With disposable resource: label with q=2 dominates q=3 → 1 path.
+    // With non-disposable resource: q=2 ≠ q=3 → neither dominates → 2 paths.
+    int from[] = {0, 1, 2, 0, 1};
+    int to[]   = {1, 2, 3, 1, 2};
+    double cost[] = {1.0, 1.0, 1.0, 1.0, 1.0};
+    double td[] = {1.0, 1.0, 1.0, 1.0, 2.0};  // arc a4 consumes 2
+
+    double tw_lb[] = {0.0, 0.0, 0.0, 0.0};
+    double tw_ub[] = {20.0, 20.0, 20.0, 20.0};
+
+    const double* arc_res[] = {td};
+    const double* v_lb[] = {tw_lb};
+    const double* v_ub[] = {tw_ub};
+
+    ProblemView pv;
+    pv.n_vertices = 4;
+    pv.source = 0;
+    pv.sink = 3;
+    pv.n_arcs = 5;
+    pv.arc_from = from;
+    pv.arc_to = to;
+    pv.arc_base_cost = cost;
+    pv.n_resources = 1;
+    pv.arc_resource = arc_res;
+    pv.vertex_lb = v_lb;
+    pv.vertex_ub = v_ub;
+    pv.n_main_resources = 1;
+
+    // Disposable (default): q=2 dominates q=3
+    BucketGraph<EmptyPack> bg_disp(pv, EmptyPack{},
+        {.bucket_steps = {5.0, 1.0}, .tolerance = 1e9,
+         .stage = Stage::Exact});
+    bg_disp.build();
+    auto paths_disp = bg_disp.solve();
+
+    // Non-disposable: q=2 ≠ q=3, neither dominates
+    bool nondisposable[] = {true};
+    pv.resource_nondisposable = nondisposable;
+    BucketGraph<EmptyPack> bg_nondisp(pv, EmptyPack{},
+        {.bucket_steps = {5.0, 1.0}, .tolerance = 1e9,
+         .stage = Stage::Exact});
+    bg_nondisp.build();
+    auto paths_nondisp = bg_nondisp.solve();
+
+    REQUIRE(!paths_disp.empty());
+    REQUIRE(!paths_nondisp.empty());
+
+    // Non-disposable should keep more paths (less dominance)
+    CHECK(paths_nondisp.size() > paths_disp.size());
+}
+
+TEST_CASE("Resource::symmetric() interface") {
+    // EmptyPack: vacuous true (no resources)
+    EmptyPack empty{};
+    CHECK(empty.symmetric() == true);
+
+    // NgPathResource: always symmetric (§4.2.2)
+    int from[] = {0, 1};
+    int to[]   = {1, 2};
+    std::vector<std::vector<int>> neighbors = {{0, 1, 2}, {0, 1, 2}, {0, 1, 2}};
+    NgPathResource ng(3, 2, from, to, neighbors);
+    CHECK(ng.symmetric() == true);
+
+    // Pack with NgPathResource: symmetric
+    auto pack = make_resource_pack(std::move(ng));
+    CHECK(pack.symmetric() == true);
+}
+
 // ── LabelPool ──
 
 TEST_CASE("LabelPool: allocation and counting") {

--- a/tests/test_resource.cpp
+++ b/tests/test_resource.cpp
@@ -61,6 +61,9 @@ TEST_CASE("ResourcePack with StandardResource") {
     auto [new_states, cost] = pack.extend(Direction::Forward, states, 0);
     CHECK(std::get<0>(new_states) == 2.0);
     CHECK(cost == 0.0);
+
+    // StandardResource is conservatively non-symmetric
+    CHECK(pack.symmetric() == false);
 }
 
 // ════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- **Heuristic2 dominance relaxed** (VRPSolver 2020 §5.1.3): cost-only dominance ignoring ng/R1C states, matching Heuristic1
- **Non-disposable resource support** (§5.1.2): `ProblemView::resource_nondisposable` flag; main resource dominance uses equality when set
- **Per-resource `symmetric()` interface** (Meta-Solver 2026 §4.1): added to Resource concept; NgPathResource=true, StandardResource=false; BucketGraph asserts on mismatch

## Test plan
- [x] Heuristic2 test: relaxed ng dominance prunes more aggressively than Exact
- [x] Non-disposable test: equality-based dominance keeps more paths than disposable
- [x] symmetric() test: EmptyPack, NgPathResource, StandardResource pack
- [x] All 111 tests pass (825 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)