### PR TITLE
Add backward exact completion bounds post-pass pruning

### DIFF
--- a/include/bgspprc/bucket_graph.h
+++ b/include/bgspprc/bucket_graph.h
@@ -252,6 +252,9 @@ public:
     /// Number of fixed buckets.
     int n_fixed_buckets() const { return fixed_.n_fixed(); }
 
+    /// Number of bw labels pruned by post-pass exact completion bounds.
+    int n_bw_labels_pruned() const { return bw_labels_pruned_; }
+
 
     void reset_elimination() {
         fixed_.clear();
@@ -1150,7 +1153,8 @@ private:
 
     /// Post-pass: mark bw labels past midpoint as dominated if no θ-compatible
     /// fw label exists via incoming arcs.  Mirror of has_compatible_opposite.
-    void prune_bw_past_midpoint(double mu) {
+    void prune_bw_past_midpoint(double mu, double theta) {
+        bw_labels_pruned_ = 0;
         for (int v = 0; v < pv_.n_vertices; ++v) {
             if (v == pv_.source || v == pv_.sink) continue;
             auto [start, end] = vertex_bucket_range(v);
@@ -1164,7 +1168,7 @@ private:
                         for (int fbi = istart; fbi < iend && !found; ++fbi) {
                             for (const auto* fw : fw_bucket_labels_[fbi]) {
                                 if (fw->dominated) continue;
-                                if (is_theta_compatible(fw, bw, arc_id, opts_.tolerance)) {
+                                if (is_theta_compatible(fw, bw, arc_id, theta)) {
                                     found = true;
                                     break;
                                 }
@@ -1172,7 +1176,10 @@ private:
                         }
                         if (found) break;
                     }
-                    if (!found) bw->dominated = true;
+                    if (!found) {
+                        bw->dominated = true;
+                        ++bw_labels_pruned_;
+                    }
                 }
             }
         }
@@ -1642,7 +1649,7 @@ private:
 
         // Post-pass: prune bw labels past midpoint with no compatible fw label
         if (!opts_.symmetric && opts_.stage != Stage::Enumerate)
-            prune_bw_past_midpoint(mu);
+            prune_bw_past_midpoint(mu, opts_.tolerance);
 
         if (opts_.symmetric) {
             // Symmetric: populate bw_c_best from fw c_best via mirror
@@ -2006,6 +2013,7 @@ private:
     // Adaptive midpoint for bidirectional labeling
     int fw_label_count_ = 0;
     int bw_label_count_ = 0;
+    int bw_labels_pruned_ = 0;
     double midpoint_ = 0.0;
     bool midpoint_initialized_ = false;
 

--- a/include/bgspprc/bucket_graph.h
+++ b/include/bgspprc/bucket_graph.h
@@ -1148,6 +1148,36 @@ private:
         return total_cost < theta;
     }
 
+    /// Post-pass: mark bw labels past midpoint as dominated if no θ-compatible
+    /// fw label exists via incoming arcs.  Mirror of has_compatible_opposite.
+    void prune_bw_past_midpoint(double mu) {
+        for (int v = 0; v < pv_.n_vertices; ++v) {
+            if (v == pv_.source || v == pv_.sink) continue;
+            auto [start, end] = vertex_bucket_range(v);
+            for (int bi = start; bi < end; ++bi) {
+                for (auto* bw : bw_bucket_labels_[bi]) {
+                    if (bw->dominated || bw->q[0] >= mu) continue;
+                    bool found = false;
+                    for (int arc_id : adj_.incoming[v]) {
+                        int i = pv_.arc_from[arc_id];
+                        auto [istart, iend] = vertex_bucket_range(i);
+                        for (int fbi = istart; fbi < iend && !found; ++fbi) {
+                            for (const auto* fw : fw_bucket_labels_[fbi]) {
+                                if (fw->dominated) continue;
+                                if (is_theta_compatible(fw, bw, arc_id, opts_.tolerance)) {
+                                    found = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (found) break;
+                    }
+                    if (!found) bw->dominated = true;
+                }
+            }
+        }
+    }
+
     /// Check if a forward label past q* has any θ-compatible backward label
     /// via across-arc concatenation (BucketGraph 2021 §5 exact completion bounds).
     /// Iterates outgoing arcs (v,j), checks bw labels at j.
@@ -1609,6 +1639,10 @@ private:
             process_scc(scc, Direction::Forward, fw_scc_buckets_,
                         fw_bucket_labels_, mu);
         }
+
+        // Post-pass: prune bw labels past midpoint with no compatible fw label
+        if (!opts_.symmetric && opts_.stage != Stage::Enumerate)
+            prune_bw_past_midpoint(mu);
 
         if (opts_.symmetric) {
             // Symmetric: populate bw_c_best from fw c_best via mirror

--- a/tests/test_bucket_graph.cpp
+++ b/tests/test_bucket_graph.cpp
@@ -2085,59 +2085,32 @@ TEST_CASE("Exact completion bounds prune fw labels past midpoint") {
 TEST_CASE("Backward exact completion bounds prune bw labels past midpoint") {
     // 6 vertices: 0=source, 1, 2, 3, 4, 5=sink.  tw [0,10], midpoint=5.
     //
+    // Two paths:
+    //   A: 0→1→5  t=3+3=6, c=1+1=2  (optimal, found via fw reaching sink)
+    //   B: 0→2→3→5  infeasible: fw at 2 has q=3, arc 2→3 t=8 → q=11>ub=10
+    //
     // Arcs:
-    //   0→1 t=1 c=1    0→2 t=1 c=1
-    //   1→3 t=1 c=1    2→4 t=1 c=1
-    //   3→5 t=1 c=1    4→5 t=1 c=1
-    //   5→4 (reverse: 4→5 already exists, but we need an incoming arc for bw)
+    //   0→1 t=3 c=1     1→5 t=3 c=1     (path A)
+    //   0→2 t=3 c=100   2→3 t=8 c=50    3→5 t=1 c=1  (path B, infeasible)
+    //   0→4 t=1 c=5     4→3 t=5 c=5     (path C below)
     //
-    // Redesigned: vertex 4 gets a bw label with q[0] < midpoint via a
-    // resource-heavy backward extension, but no fw label can reach it
-    // compatibly.
+    // Bw label at vertex 2: seed at 5 q=10, extend 3→5 bw q=9, extend 2→3 bw
+    //   q=min(9-8,10)=1 < mu=5. Past midpoint.
+    //   Incoming arcs of 2: only 0→2 (t=3). fw at 0: q=0.
+    //   fw_after = max(0+3,0) = 3 > bw_q=1 → INCOMPATIBLE → pruned.
     //
-    // Graph (all times forward):
-    //   0→1 t=3 c=1     main path start
-    //   1→5 t=3 c=1     main path end
-    //   0→2 t=1 c=100   detour start (expensive)
-    //   2→3 t=7 c=50    detour: eats time so bw label at 2 has low q
-    //   3→5 t=1 c=1     detour end
+    // Bw label at vertex 4: extend 4→3 bw q=min(9-5,10)=4 < mu=5.
+    //   Incoming arcs of 4: only 0→4 (t=1). fw at 0: q=0.
+    //   fw_after = max(0+1,0) = 1 ≤ bw_q=4 → COMPATIBLE → NOT pruned.
+    //   Path C: 0→4→3→5, t=1+5+1=7, c=5+5+1=11. Found via concatenation.
     //
-    // Bw from 5: bw label at 3 has q=9 (10-1=9). Extend 3→2: q=9-7=2 < mu=5.
-    // Fw from 0: fw label at 2 has q=1. Arc 2→3 has time=7.
-    //   fw_after = 1+7 = 8. bw q at 3 = 9. 8 ≤ 9 → compatible for arc 2→3.
-    // So bw label at vertex 2 (q=2) IS compatible via incoming arc 0→2:
-    //   fw at 0 has q=0, arc 0→2 time=1, fw_after = max(0+1,0) = 1.
-    //   bw at 2 has q=2. 1 ≤ 2 → compatible! Cost = 0+102+1+100 = 203.
-    //
-    // Need to make the bw label at 2 truly incompatible:
-    // Give vertex 2 a tight lower bound so fw extension can't match.
-    //
-    // Final design:
-    //   0→1 t=3 c=1     1→5 t=3 c=1     (optimal: cost=2, time=6)
-    //   0→2 t=1 c=100   2→3 t=8 c=50    3→5 t=1 c=1
-    //   vertex 2: lb=0, ub=10
-    //   vertex 3: lb=0, ub=10
-    //
-    // Bw label at 2: q=10-8=2 (via 3←sink←, then 2←3), but actually
-    // bw extends from 5 backward. Let me trace carefully:
-    //   bw seed at 5: q=10. Extend 3→5 backward: q = min(10-1, ub[3]=10) = 9.
-    //   bw at 3: q=9.  Extend 2→3 backward: q = min(9-8, ub[2]=10) = 1.
-    //   bw at 2: q=1 < mu=5. This bw label is past midpoint.
-    //
-    // Check incoming arcs of vertex 2: only arc 0→2.
-    //   fw at 0: q=0, cost=0. Arc 0→2: time=1, cost=100.
-    //   fw_after = max(0+1, lb[2]=0) = 1. bw q at 2 = 1. 1 ≤ 1+eps → compatible!
-    //
-    // Still compatible. Need fw_after > bw_q. Set arc 0→2 time = 3:
-    //   fw_after = max(0+3, 0) = 3 > bw q=1 → INCOMPATIBLE. ✓
-    //
-    // But then fw at 2 has q=3, arc 2→3 time=8: q=3+8=11 > ub=10 → infeasible.
-    // So path 0→2→3→5 is infeasible in mono too. Both agree.
+    // Both mono and bidir find paths A (cost=2) and C (cost=11).
+    // Bw label at vertex 2 is pruned (n_bw_labels_pruned ≥ 1).
 
-    int from[5]      = {0, 0, 1, 2, 3};
-    int to[5]        = {1, 2, 5, 3, 5};
-    double cost[5]   = {1.0, 100.0, 1.0, 50.0, 1.0};
-    double time_d[5] = {3.0, 3.0, 3.0, 8.0, 1.0};
+    int from[7]      = {0, 0, 0, 1, 2, 3, 4};
+    int to[7]        = {1, 2, 4, 5, 3, 5, 3};
+    double cost[7]   = {1.0, 100.0, 5.0, 1.0, 50.0, 1.0, 5.0};
+    double time_d[7] = {3.0, 3.0, 1.0, 3.0, 8.0, 1.0, 5.0};
 
     double tw_lb[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     double tw_ub[6] = {10.0, 10.0, 10.0, 10.0, 10.0, 10.0};
@@ -2150,7 +2123,7 @@ TEST_CASE("Backward exact completion bounds prune bw labels past midpoint") {
     pv.n_vertices = 6;
     pv.source = 0;
     pv.sink = 5;
-    pv.n_arcs = 5;
+    pv.n_arcs = 7;
     pv.arc_from = from;
     pv.arc_to = to;
     pv.arc_base_cost = cost;
@@ -2168,8 +2141,7 @@ TEST_CASE("Backward exact completion bounds prune bw labels past midpoint") {
     REQUIRE(!mono_paths.empty());
     CHECK(mono_paths[0].reduced_cost == doctest::Approx(2.0));
 
-    // Bidir solve — bw label at vertex 2 (q=1 < mu=5) should be pruned
-    // because fw_after=3 > bw_q=1 for the only incoming arc 0→2.
+    // Bidir solve
     BucketGraph<EmptyPack> bidir(pv, EmptyPack{},
         {.bucket_steps = {1.0, 1.0}, .tolerance = 1e9, .bidirectional = true,
          .stage = Stage::Exact});
@@ -2178,6 +2150,9 @@ TEST_CASE("Backward exact completion bounds prune bw labels past midpoint") {
     REQUIRE(!bidir_paths.empty());
     CHECK(bidir_paths[0].reduced_cost ==
           doctest::Approx(mono_paths[0].reduced_cost));
+
+    // Verify pruning actually happened (bw label at vertex 2 was pruned)
+    CHECK(bidir.n_bw_labels_pruned() >= 1);
 }
 
 #endif  // !_WIN32

--- a/tests/test_bucket_graph.cpp
+++ b/tests/test_bucket_graph.cpp
@@ -2082,4 +2082,102 @@ TEST_CASE("Exact completion bounds prune fw labels past midpoint") {
           doctest::Approx(mono_paths[0].reduced_cost));
 }
 
+TEST_CASE("Backward exact completion bounds prune bw labels past midpoint") {
+    // 6 vertices: 0=source, 1, 2, 3, 4, 5=sink.  tw [0,10], midpoint=5.
+    //
+    // Arcs:
+    //   0→1 t=1 c=1    0→2 t=1 c=1
+    //   1→3 t=1 c=1    2→4 t=1 c=1
+    //   3→5 t=1 c=1    4→5 t=1 c=1
+    //   5→4 (reverse: 4→5 already exists, but we need an incoming arc for bw)
+    //
+    // Redesigned: vertex 4 gets a bw label with q[0] < midpoint via a
+    // resource-heavy backward extension, but no fw label can reach it
+    // compatibly.
+    //
+    // Graph (all times forward):
+    //   0→1 t=3 c=1     main path start
+    //   1→5 t=3 c=1     main path end
+    //   0→2 t=1 c=100   detour start (expensive)
+    //   2→3 t=7 c=50    detour: eats time so bw label at 2 has low q
+    //   3→5 t=1 c=1     detour end
+    //
+    // Bw from 5: bw label at 3 has q=9 (10-1=9). Extend 3→2: q=9-7=2 < mu=5.
+    // Fw from 0: fw label at 2 has q=1. Arc 2→3 has time=7.
+    //   fw_after = 1+7 = 8. bw q at 3 = 9. 8 ≤ 9 → compatible for arc 2→3.
+    // So bw label at vertex 2 (q=2) IS compatible via incoming arc 0→2:
+    //   fw at 0 has q=0, arc 0→2 time=1, fw_after = max(0+1,0) = 1.
+    //   bw at 2 has q=2. 1 ≤ 2 → compatible! Cost = 0+102+1+100 = 203.
+    //
+    // Need to make the bw label at 2 truly incompatible:
+    // Give vertex 2 a tight lower bound so fw extension can't match.
+    //
+    // Final design:
+    //   0→1 t=3 c=1     1→5 t=3 c=1     (optimal: cost=2, time=6)
+    //   0→2 t=1 c=100   2→3 t=8 c=50    3→5 t=1 c=1
+    //   vertex 2: lb=0, ub=10
+    //   vertex 3: lb=0, ub=10
+    //
+    // Bw label at 2: q=10-8=2 (via 3←sink←, then 2←3), but actually
+    // bw extends from 5 backward. Let me trace carefully:
+    //   bw seed at 5: q=10. Extend 3→5 backward: q = min(10-1, ub[3]=10) = 9.
+    //   bw at 3: q=9.  Extend 2→3 backward: q = min(9-8, ub[2]=10) = 1.
+    //   bw at 2: q=1 < mu=5. This bw label is past midpoint.
+    //
+    // Check incoming arcs of vertex 2: only arc 0→2.
+    //   fw at 0: q=0, cost=0. Arc 0→2: time=1, cost=100.
+    //   fw_after = max(0+1, lb[2]=0) = 1. bw q at 2 = 1. 1 ≤ 1+eps → compatible!
+    //
+    // Still compatible. Need fw_after > bw_q. Set arc 0→2 time = 3:
+    //   fw_after = max(0+3, 0) = 3 > bw q=1 → INCOMPATIBLE. ✓
+    //
+    // But then fw at 2 has q=3, arc 2→3 time=8: q=3+8=11 > ub=10 → infeasible.
+    // So path 0→2→3→5 is infeasible in mono too. Both agree.
+
+    int from[5]      = {0, 0, 1, 2, 3};
+    int to[5]        = {1, 2, 5, 3, 5};
+    double cost[5]   = {1.0, 100.0, 1.0, 50.0, 1.0};
+    double time_d[5] = {3.0, 3.0, 3.0, 8.0, 1.0};
+
+    double tw_lb[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    double tw_ub[6] = {10.0, 10.0, 10.0, 10.0, 10.0, 10.0};
+
+    const double* arc_res[1]   = {time_d};
+    const double* v_lb[1]      = {tw_lb};
+    const double* v_ub[1]      = {tw_ub};
+
+    ProblemView pv;
+    pv.n_vertices = 6;
+    pv.source = 0;
+    pv.sink = 5;
+    pv.n_arcs = 5;
+    pv.arc_from = from;
+    pv.arc_to = to;
+    pv.arc_base_cost = cost;
+    pv.n_resources = 1;
+    pv.arc_resource = arc_res;
+    pv.vertex_lb = v_lb;
+    pv.vertex_ub = v_ub;
+    pv.n_main_resources = 1;
+
+    // Mono solve for reference
+    BucketGraph<EmptyPack> mono(pv, EmptyPack{},
+        {.bucket_steps = {1.0, 1.0}, .tolerance = 1e9});
+    mono.build();
+    auto mono_paths = mono.solve();
+    REQUIRE(!mono_paths.empty());
+    CHECK(mono_paths[0].reduced_cost == doctest::Approx(2.0));
+
+    // Bidir solve — bw label at vertex 2 (q=1 < mu=5) should be pruned
+    // because fw_after=3 > bw_q=1 for the only incoming arc 0→2.
+    BucketGraph<EmptyPack> bidir(pv, EmptyPack{},
+        {.bucket_steps = {1.0, 1.0}, .tolerance = 1e9, .bidirectional = true,
+         .stage = Stage::Exact});
+    bidir.build();
+    auto bidir_paths = bidir.solve();
+    REQUIRE(!bidir_paths.empty());
+    CHECK(bidir_paths[0].reduced_cost ==
+          doctest::Approx(mono_paths[0].reduced_cost));
+}
+
 #endif  // !_WIN32


### PR DESCRIPTION
## Summary
- Add `prune_bw_past_midpoint()` post-pass after fw labeling that marks bw labels past q* as dominated when no θ-compatible fw label exists via incoming arcs
- Mirror of forward exact completion bounds (PR #8) — fw pruning happens at creation time, but bw labels can only be pruned after fw labeling completes
- Dominated bw labels are skipped by `concatenate_and_extract`, reducing useless concatenation scans

## Test plan
- [x] New test case: graph where bw label at vertex 2 has q=1 < mu=5 but fw_after=3 > bw_q=1 for only incoming arc — verifies label is pruned and bidir matches mono
- [x] All 113 tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)