### PR TITLE
Fetch doctest via FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,13 @@ target_compile_features(bgspprc INTERFACE cxx_std_23)
 option(BGSPPRC_BUILD_TESTS "Build unit tests" ${PROJECT_IS_TOP_LEVEL})
 
 if(BGSPPRC_BUILD_TESTS)
+    include(FetchContent)
+    FetchContent_Declare(
+        doctest
+        GIT_REPOSITORY https://github.com/doctest/doctest.git
+        GIT_TAG v2.4.12)
+    FetchContent_MakeAvailable(doctest)
+
     enable_testing()
 
     # Compiler flags for project targets only (not propagated to consumers)
@@ -22,15 +29,15 @@ if(BGSPPRC_BUILD_TESTS)
         tests/test_resource.cpp
         tests/test_bucket_graph.cpp
         tests/test_small_instance.cpp)
-    target_link_libraries(test_runner PRIVATE bgspprc)
+    target_link_libraries(test_runner PRIVATE bgspprc doctest::doctest)
     add_test(NAME unit_tests COMMAND test_runner)
 
     add_executable(bench_runner tests/test_main.cpp tests/test_benchmarks.cpp)
-    target_link_libraries(bench_runner PRIVATE bgspprc)
+    target_link_libraries(bench_runner PRIVATE bgspprc doctest::doctest)
 
     add_executable(bench_run tests/bench_run.cpp)
-    target_link_libraries(bench_run PRIVATE bgspprc)
+    target_link_libraries(bench_run PRIVATE bgspprc doctest::doctest)
 
     add_executable(bench_vs_pathwyse tests/bench_vs_pathwyse.cpp)
-    target_link_libraries(bench_vs_pathwyse PRIVATE bgspprc)
+    target_link_libraries(bench_vs_pathwyse PRIVATE bgspprc doctest::doctest)
 endif()

--- a/tests/test_benchmarks.cpp
+++ b/tests/test_benchmarks.cpp
@@ -8,7 +8,7 @@
 #include <map>
 #include <string>
 
-#include "doctest.h"
+#include <doctest/doctest.h>
 #include "instance_io.h"
 
 using namespace bgspprc;

--- a/tests/test_bucket_graph.cpp
+++ b/tests/test_bucket_graph.cpp
@@ -6,7 +6,7 @@
 
 #include <cstdio>
 
-#include "doctest.h"
+#include <doctest/doctest.h>
 #ifndef _WIN32
 #include <unistd.h>
 #endif

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,2 +1,2 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include "doctest.h"
+#include <doctest/doctest.h>

--- a/tests/test_resource.cpp
+++ b/tests/test_resource.cpp
@@ -5,7 +5,7 @@
 #include <bgspprc/resources/standard.h>
 #include <bgspprc/solver.h>
 
-#include "doctest.h"
+#include <doctest/doctest.h>
 
 using namespace bgspprc;
 

--- a/tests/test_small_instance.cpp
+++ b/tests/test_small_instance.cpp
@@ -1,7 +1,7 @@
 #include <bgspprc/resource.h>
 #include <bgspprc/solver.h>
 
-#include "doctest.h"
+#include <doctest/doctest.h>
 
 using namespace bgspprc;
 


### PR DESCRIPTION
## Summary
- Replace vendored `tests/doctest.h` with CMake `FetchContent` (v2.4.12)
- Update includes from `"doctest.h"` to `<doctest/doctest.h>`

## Test plan
- [x] `cmake -B build -DCMAKE_CXX_COMPILER=g++-14 && cmake --build build` compiles
- [x] `ctest --test-dir build` — 146 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)