### PR TITLE
Fix bidir concatenation: default max_paths to unlimited

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -77,6 +77,7 @@ static Result run_sppcc(const std::string& path, const Options& opts) {
     Solver<NgPack> solver(pv, make_resource_pack(std::move(ng)),
                           {.bucket_steps = {s1, s2},
                            .bidirectional = opts.bidir,
+                           .max_paths = 100,
                            .tolerance = 1e9});
     solver.build();
     solver.set_stage(opts.stage);
@@ -98,6 +99,7 @@ static Result run_sppcc(const std::string& path, const Options& opts) {
     Solver<EmptyPack> solver(pv, EmptyPack{},
                              {.bucket_steps = {s1, s2},
                               .bidirectional = opts.bidir,
+                              .max_paths = 100,
                               .tolerance = 1e9});
     solver.build();
     solver.set_stage(opts.stage);
@@ -137,6 +139,7 @@ static Result run_vrp(const std::string& path, const Options& opts) {
     Solver<NgPack> solver(pv, make_resource_pack(std::move(ng)),
                           {.bucket_steps = {s1, s2},
                            .bidirectional = opts.bidir,
+                           .max_paths = 100,
                            .tolerance = 1e9});
     solver.build();
     solver.set_stage(opts.stage);
@@ -158,6 +161,7 @@ static Result run_vrp(const std::string& path, const Options& opts) {
     Solver<EmptyPack> solver(pv, EmptyPack{},
                              {.bucket_steps = {s1, s2},
                               .bidirectional = opts.bidir,
+                              .max_paths = 100,
                               .tolerance = 1e9});
     solver.build();
     solver.set_stage(opts.stage);
@@ -194,6 +198,7 @@ static Result run_graph(const std::string& path, const Options& opts) {
     Solver<EmptyPack> solver(pv, EmptyPack{},
                              {.bucket_steps = {s1, s2},
                               .bidirectional = opts.bidir,
+                              .max_paths = 100,
                               .tolerance = 0.0});
     solver.build();
     solver.set_stage(opts.stage);
@@ -224,6 +229,7 @@ static Result run_graph(const std::string& path, const Options& opts) {
     Solver<NgPack> solver(pv, make_resource_pack(std::move(ng)),
                           {.bucket_steps = {s1, s2},
                            .bidirectional = opts.bidir,
+                           .max_paths = 100,
                            .tolerance = 0.0});
     solver.build();
     solver.set_stage(opts.stage);

--- a/include/bgspprc/bucket_graph.h
+++ b/include/bgspprc/bucket_graph.h
@@ -33,7 +33,7 @@ class BucketGraph {
  public:
   struct Options {
     std::array<double, 2> bucket_steps = {1.0, 1.0};
-    int max_paths = 100;
+    int max_paths = 0;  // 0 = unlimited
     double tolerance = -1e-6;
     bool bidirectional = false;
     bool symmetric = false;  // skip backward labeling, use fw labels as bw
@@ -831,7 +831,7 @@ class BucketGraph {
         enum_complete_ = false;
         return true;
       }
-      if (enumerating && enum_sink_labels_ >= opts_.max_paths) {
+      if (enumerating && opts_.max_paths > 0 && enum_sink_labels_ >= opts_.max_paths) {
         enum_complete_ = false;
         return true;
       }
@@ -1531,7 +1531,15 @@ class BucketGraph {
                   INF);
     }
 
-    return extract_paths(fw_bucket_labels_);
+    auto paths = extract_paths(fw_bucket_labels_);
+    std::sort(paths.begin(), paths.end(), [](const Path& a, const Path& b) {
+      return a.reduced_cost < b.reduced_cost;
+    });
+    if (opts_.max_paths > 0 && static_cast<int>(paths.size()) > opts_.max_paths) {
+      paths.resize(opts_.max_paths);
+      if (opts_.stage == Stage::Enumerate) enum_complete_ = false;
+    }
+    return paths;
   }
 
   // ── Bi-directional solve ──
@@ -1643,7 +1651,7 @@ class BucketGraph {
     std::sort(paths.begin(), paths.end(), [](const Path& a, const Path& b) {
       return a.reduced_cost < b.reduced_cost;
     });
-    if (static_cast<int>(paths.size()) > opts_.max_paths) {
+    if (opts_.max_paths > 0 && static_cast<int>(paths.size()) > opts_.max_paths) {
       paths.resize(opts_.max_paths);
       if (opts_.stage == Stage::Enumerate) enum_complete_ = false;
     }
@@ -1760,10 +1768,6 @@ class BucketGraph {
               p.reduced_cost = total_cost;
               p.original_cost = total_real_cost;
               paths.push_back(std::move(p));
-              if (static_cast<int>(paths.size()) >= opts_.max_paths) {
-                if (opts_.stage == Stage::Enumerate) enum_complete_ = false;
-                return;
-              }
             }
           }
         }
@@ -1791,15 +1795,6 @@ class BucketGraph {
           paths.push_back(std::move(p));
         }
       }
-    }
-
-    std::sort(paths.begin(), paths.end(), [](const Path& a, const Path& b) {
-      return a.reduced_cost < b.reduced_cost;
-    });
-
-    if (static_cast<int>(paths.size()) > opts_.max_paths) {
-      paths.resize(opts_.max_paths);
-      if (opts_.stage == Stage::Enumerate) enum_complete_ = false;
     }
 
     return paths;

--- a/include/bgspprc/solver.h
+++ b/include/bgspprc/solver.h
@@ -22,7 +22,7 @@ class Solver {
     std::array<double, 2> bucket_steps = {1.0, 1.0};
     bool bidirectional = false;
     bool symmetric = false;
-    int max_paths = 100;
+    int max_paths = 0;  // 0 = unlimited
     double tolerance = -1e-6;
     int max_enum_labels = 5000000;
   };


### PR DESCRIPTION
## Summary
- `concatenate_and_extract()` stopped at `max_paths` (100) while iterating arcs in ID order, missing optimal paths from later arcs. Bidir returned suboptimal solutions (e.g. cost=0 instead of -16517 on A-n60-k9-57.sppcc with ng=8).
- Default `max_paths` to 0 (unlimited) so library users get correct results by default. CLI explicitly sets `max_paths=100` to preserve the performance cap.
- Centralize sort+truncate in `solve_mono()`/`solve_bidirectional()` instead of in `extract_paths()`/`concatenate_and_extract()`.

## Test plan
- [x] All 146 unit tests pass
- [x] `bgspprc-solve --ng 0` bidir vs mono match on A-n60-k9-57.sppcc (-91623)
- [x] `bgspprc-solve --ng 8` bidir vs mono match on A-n60-k9-57.sppcc (-16517)

🤖 Generated with [Claude Code](https://claude.com/claude-code)