### PR TITLE
Fix ng inference in run_benchmarks.sh for RCSPP

### DIFF
--- a/benchmarks/run_benchmarks.sh
+++ b/benchmarks/run_benchmarks.sh
@@ -109,10 +109,13 @@ infer_ng() {
     echo "${NG_FLAG[1]}"
     return
   fi
-  # For .graph files, infer from grandparent dir name (e.g. ng16 → 16)
-  local grandparent
+  # Infer from parent or grandparent dir name matching ng[0-9]+
+  local parent grandparent
+  parent="$(basename "$(dirname "$1")")"
   grandparent="$(basename "$(dirname "$(dirname "$1")")")"
-  if [[ "$grandparent" =~ ^ng([0-9]+)$ ]]; then
+  if [[ "$parent" =~ ^ng([0-9]+)$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+  elif [[ "$grandparent" =~ ^ng([0-9]+)$ ]]; then
     echo "${BASH_REMATCH[1]}"
   else
     echo ""


### PR DESCRIPTION
## Summary
- `infer_ng` checked only the grandparent directory for the `ng[0-9]+` pattern, but RCSPP paths are `rcspp/ng16/C101.graph` where `ng16` is the parent directory.
- Now checks parent dir first, grandparent as fallback. Fixes empty ng column in CSV for RCSPP instances.

## Test plan
- [x] Verified CSV output: `C101,ng16,16,...` (was `C101,ng16,,...`)
- [x] Full RCSPP benchmark run (168 instances) produces correct ng=8/16/24 values
- [x] check_optimal.sh shows correct ng column for all RCSPP rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)