### PR TITLE
Refactor R1CResource to conform to Resource concept (64-cut cap)

### DIFF
--- a/include/bgspprc/bucket_graph.h
+++ b/include/bgspprc/bucket_graph.h
@@ -19,7 +19,6 @@
 #include "bucket.h"
 #include "label.h"
 #include "problem_view.h"
-#include "r1c.h"
 #include "resource.h"
 #include "types.h"
 
@@ -77,10 +76,10 @@ class BucketGraph {
     reduced_costs_ = reduced_costs;
   }
 
-  /// Set R1C cuts (rebuilds masks, resizes label R1C state).
-  void set_r1c_cuts(std::span<const R1Cut> cuts) {
-    r1c_.set_cuts(cuts, pv_.n_vertices, pv_.n_arcs);
-    pool_.set_r1c_words(r1c_.n_words());
+  /// Access a resource in the pack (for runtime reconfiguration).
+  template <typename R>
+  R& resource() {
+    return std::get<R>(pack_.resources);
   }
 
   struct Path {
@@ -657,16 +656,6 @@ class BucketGraph {
       L->cost += arc_cost + vtx_cost;
     }
 
-    // R1C extension
-    if (r1c_.has_cuts() && parent->r1c_states && L->r1c_states) {
-      double r1c_cost = r1c_.extend(
-          dir,
-          {parent->r1c_states, static_cast<std::size_t>(parent->n_r1c_words)},
-          {L->r1c_states, static_cast<std::size_t>(L->n_r1c_words)}, arc_id,
-          new_v);
-      L->cost += r1c_cost;
-    }
-
     // Compute correct target bucket
     L->bucket = vertex_bucket_index(new_v, L->q);
     return L;
@@ -699,13 +688,6 @@ class BucketGraph {
     if constexpr (Pack::size > 0) {
       dom_cost += pack_.domination_cost(dir, L1->vertex, L1->resource_states,
                                         L2->resource_states);
-    }
-
-    if (r1c_.has_cuts() && L1->r1c_states && L2->r1c_states) {
-      dom_cost += r1c_.domination_cost(
-          dir, L1->vertex,
-          {L1->r1c_states, static_cast<std::size_t>(L1->n_r1c_words)},
-          {L2->r1c_states, static_cast<std::size_t>(L2->n_r1c_words)});
     }
 
     return dom_cost <= L2->cost + EPS;
@@ -1123,21 +1105,6 @@ class BucketGraph {
       total_cost += cc;
     }
 
-    if (r1c_.has_cuts() && fw->r1c_states && bw->r1c_states) {
-      uint64_t r1c_buf[4];
-      auto nw = r1c_.n_words();
-      std::vector<uint64_t> r1c_heap;
-      uint64_t* r1c_ext = r1c_buf;
-      if (nw > 4) { r1c_heap.resize(nw); r1c_ext = r1c_heap.data(); }
-      total_cost += r1c_.extend_along_arc(
-          {fw->r1c_states, static_cast<std::size_t>(fw->n_r1c_words)},
-          {r1c_ext, static_cast<std::size_t>(nw)}, arc_id);
-      total_cost += r1c_.concatenation_cost(
-          Symmetry::Asymmetric, j,
-          {r1c_ext, static_cast<std::size_t>(nw)},
-          {bw->r1c_states, static_cast<std::size_t>(bw->n_r1c_words)});
-    }
-
     return total_cost < theta;
   }
 
@@ -1494,10 +1461,6 @@ class BucketGraph {
       L->resource_states = vtx_states;
       L->cost += vtx_cost;
     }
-    if (r1c_.has_cuts()) {
-      r1c_.init_state(
-          {L->r1c_states, static_cast<std::size_t>(L->n_r1c_words)});
-    }
     return L;
   }
 
@@ -1759,21 +1722,6 @@ class BucketGraph {
               total_cost += cc;
             }
 
-            if (r1c_.has_cuts() && fw->r1c_states && bw->r1c_states) {
-              uint64_t r1c_buf[4];
-              auto nw = r1c_.n_words();
-              std::vector<uint64_t> r1c_heap;
-              uint64_t* r1c_ext = r1c_buf;
-              if (nw > 4) { r1c_heap.resize(nw); r1c_ext = r1c_heap.data(); }
-              total_cost += r1c_.extend_along_arc(
-                  {fw->r1c_states, static_cast<std::size_t>(fw->n_r1c_words)},
-                  {r1c_ext, static_cast<std::size_t>(nw)}, a);
-              total_cost += r1c_.concatenation_cost(
-                  sym, j,
-                  {r1c_ext, static_cast<std::size_t>(nw)},
-                  {bw->r1c_states, static_cast<std::size_t>(bw->n_r1c_words)});
-            }
-
             if (total_cost < opts_.tolerance) {
               Path p;
               fw->get_path(p.vertices, p.arcs);
@@ -1921,7 +1869,6 @@ class BucketGraph {
     std::array<double, 2> q;
     int parent_arc;  // last arc (for path, not critical for warm start)
     typename Pack::StatesTuple resource_states;
-    std::vector<uint64_t> r1c_state;
   };
   std::vector<WarmLabel> warm_labels_;
 
@@ -1957,9 +1904,6 @@ class BucketGraph {
       wl.q = L->q;
       wl.parent_arc = L->parent_arc;
       wl.resource_states = L->resource_states;
-      if (L->r1c_states && L->n_r1c_words > 0) {
-        wl.r1c_state.assign(L->r1c_states, L->r1c_states + L->n_r1c_words);
-      }
       warm_labels_.push_back(std::move(wl));
     }
   }
@@ -1978,12 +1922,6 @@ class BucketGraph {
       L->parent = nullptr;  // warm labels have no parent chain
       L->parent_arc = wl.parent_arc;
       L->resource_states = wl.resource_states;
-
-      if (!wl.r1c_state.empty() && L->r1c_states) {
-        int words =
-            std::min(static_cast<int>(wl.r1c_state.size()), L->n_r1c_words);
-        std::copy_n(wl.r1c_state.data(), words, L->r1c_states);
-      }
 
       int bi = vertex_bucket_index(wl.vertex, wl.q);
       L->bucket = bi;
@@ -2007,7 +1945,6 @@ class BucketGraph {
   bool midpoint_initialized_ = false;
 
   LabelPool<Pack> pool_;
-  R1CManager r1c_;
 };
 
 }  // namespace bgspprc

--- a/include/bgspprc/label.h
+++ b/include/bgspprc/label.h
@@ -37,11 +37,6 @@ struct Label {
   // Compile-time resource states
   typename Pack::StatesTuple resource_states{};
 
-  // lm-R1C states: dynamically sized, allocated alongside label
-  // n_r1c_words is set by the solver based on active cuts
-  uint64_t* r1c_states = nullptr;
-  int n_r1c_words = 0;
-
   /// Reconstruct path from source to this label (forward labels).
   void get_path(std::vector<int>& vertices, std::vector<int>& arcs) const {
     vertices.clear();
@@ -71,12 +66,11 @@ struct Label {
 /// Arena-style pool allocator for labels.
 ///
 /// Allocates labels in large blocks for cache locality.
-/// Labels can carry extra R1C state words allocated inline.
 template <typename Pack>
 class LabelPool {
  public:
-  explicit LabelPool(int r1c_words = 0, std::size_t block_size = 4096)
-      : r1c_words_(r1c_words), block_size_(block_size) {}
+  explicit LabelPool(std::size_t block_size = 4096)
+      : block_size_(block_size) {}
 
   ~LabelPool() { clear(); }
 
@@ -85,24 +79,12 @@ class LabelPool {
   LabelPool(LabelPool&&) = default;
   LabelPool& operator=(LabelPool&&) = default;
 
-  void set_r1c_words(int n) { r1c_words_ = n; }
-  int r1c_words() const { return r1c_words_; }
-
   Label<Pack>* allocate() {
     if (free_pos_ >= current_block_end_) {
       allocate_block();
     }
     auto* label = reinterpret_cast<Label<Pack>*>(free_pos_);
     new (label) Label<Pack>{};
-
-    auto* r1c_ptr =
-        reinterpret_cast<uint64_t*>(free_pos_ + sizeof(Label<Pack>));
-
-    if (r1c_words_ > 0) {
-      std::memset(r1c_ptr, 0, r1c_words_ * sizeof(uint64_t));
-      label->r1c_states = r1c_ptr;
-      label->n_r1c_words = r1c_words_;
-    }
 
     free_pos_ += label_size();
     ++count_;
@@ -123,8 +105,8 @@ class LabelPool {
 
  private:
   std::size_t label_size() const {
-    // Label + inline R1C words, aligned to 8 bytes
-    std::size_t sz = sizeof(Label<Pack>) + r1c_words_ * sizeof(uint64_t);
+    // Align to 8 bytes
+    std::size_t sz = sizeof(Label<Pack>);
     return (sz + 7) & ~std::size_t{7};
   }
 
@@ -143,7 +125,6 @@ class LabelPool {
     current_block_end_ = block + bytes;
   }
 
-  int r1c_words_ = 0;
   std::size_t block_size_ = 4096;
   std::vector<char*> blocks_;
   char* free_pos_ = nullptr;

--- a/include/bgspprc/r1c.h
+++ b/include/bgspprc/r1c.h
@@ -29,6 +29,23 @@ struct R1Cut {
 struct R1CResource {
   using State = uint64_t;
 
+  /// Set the active cuts. Rebuilds all lookup masks.
+  /// Asserts ≤ 64 cuts (single uint64_t state).
+  void set_cuts(std::span<const R1Cut> cuts, int n_vertices, int n_arcs) {
+    assert(cuts.size() <= 64 && "R1CResource supports at most 64 cuts");
+    n_vertices_ = n_vertices;
+    n_arcs_ = n_arcs;
+    cuts_.assign(cuts.begin(), cuts.end());
+    n_active_ = static_cast<int>(cuts_.size());
+
+    build_masks();
+    precompute_betas();
+  }
+
+  int n_active() const { return n_active_; }
+
+  // ── Resource concept interface ──
+
   bool symmetric() const { return true; }
 
   State init_state(Direction /*dir*/) const { return 0ULL; }
@@ -78,23 +95,6 @@ struct R1CResource {
                                 State /*s_bw*/) const {
     return 0.0;
   }
-
-  // ── Mutable configuration ──
-
-  /// Set the active cuts. Rebuilds all lookup masks.
-  /// Asserts ≤ 64 cuts (single uint64_t state).
-  void set_cuts(std::span<const R1Cut> cuts, int n_vertices, int n_arcs) {
-    assert(cuts.size() <= 64 && "R1CResource supports at most 64 cuts");
-    n_vertices_ = n_vertices;
-    n_arcs_ = n_arcs;
-    cuts_.assign(cuts.begin(), cuts.end());
-    n_active_ = static_cast<int>(cuts_.size());
-
-    build_masks();
-    precompute_betas();
-  }
-
-  int n_active() const { return n_active_; }
 
  private:
   void build_masks() {

--- a/include/bgspprc/r1c.h
+++ b/include/bgspprc/r1c.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <algorithm>
 #include <bit>
 #include <cassert>
 #include <cstdint>
-#include <cstring>
 #include <span>
+#include <utility>
 #include <vector>
 
 #include "types.h"
@@ -20,181 +19,121 @@ struct R1Cut {
   double dual_value = 0.0;  // σ_ℓ (dual variable, β = -σ_ℓ > 0)
 };
 
-/// Built-in lm-R1C engine for arc-memory limited-memory Rank-1 Cuts.
+/// lm-R1C resource conforming to the Resource concept.
 ///
-/// Specialized for 3-Subset Row Cuts (|C|=3, p_v=1/2), which are the most
-/// common. State per cut: 1 bit (s ∈ {0, 1/2}), packed 64 per uint64_t word.
+/// Specialized for 3-Subset Row Cuts (|C|=3, p_v=1/2). State per cut: 1 bit,
+/// packed into a single uint64_t (max 64 active cuts).
 ///
-/// Operations are bitwise on packed words for performance.
-class R1CManager {
- public:
-  R1CManager() = default;
+/// extend_along_arc: memory reset (keep bits for cuts where arc ∈ AM)
+/// extend_to_vertex: toggle bits for cuts where vertex ∈ C, cost from overflow
+struct R1CResource {
+  using State = uint64_t;
+
+  bool symmetric() const { return true; }
+
+  State init_state(Direction /*dir*/) const { return 0ULL; }
+
+  /// Memory reset along arc: keep bits for cuts where arc ∈ AM.
+  std::pair<State, double> extend_along_arc(Direction /*dir*/, State state,
+                                            int arc_id) const {
+    if (n_active_ == 0) return {state, 0.0};
+    return {state & arc_keep_mask_[arc_id], 0.0};
+  }
+
+  /// Toggle bits for cuts where vertex ∈ C. Overflow (1→0) applies cost -β.
+  std::pair<State, double> extend_to_vertex(Direction /*dir*/, State state,
+                                            int vertex) const {
+    if (n_active_ == 0) return {state, 0.0};
+
+    uint64_t toggle = vertex_toggle_mask_[vertex];
+    uint64_t overflow = state & toggle;
+    state ^= toggle;
+
+    double cost = 0.0;
+    if (overflow) cost = compute_overflow_cost(overflow);
+    return {state, cost};
+  }
+
+  /// Extra cost L1 pays vs L2: penalty for cuts where s2 has credit but s1
+  /// doesn't.
+  double domination_cost(Direction /*dir*/, int /*vertex*/, State s1,
+                         State s2) const {
+    if (n_active_ == 0) return 0.0;
+    uint64_t disadvantage = s2 & ~s1;
+    if (disadvantage) return compute_overflow_cost(disadvantage);
+    return 0.0;
+  }
+
+  /// Cost when joining fw/bw labels: if both have credit, overflow.
+  double concatenation_cost(Symmetry /*sym*/, int /*vertex*/, State s_fw,
+                            State s_bw) const {
+    if (n_active_ == 0) return 0.0;
+    uint64_t both = s_fw & s_bw;
+    if (both) return compute_overflow_cost(both);
+    return 0.0;
+  }
+
+  /// No arc-level concatenation cost for R1C.
+  double arc_concatenation_cost(Symmetry /*sym*/, int /*arc_id*/, State /*s_fw*/,
+                                State /*s_bw*/) const {
+    return 0.0;
+  }
+
+  // ── Mutable configuration ──
 
   /// Set the active cuts. Rebuilds all lookup masks.
+  /// Asserts ≤ 64 cuts (single uint64_t state).
   void set_cuts(std::span<const R1Cut> cuts, int n_vertices, int n_arcs) {
+    assert(cuts.size() <= 64 && "R1CResource supports at most 64 cuts");
     n_vertices_ = n_vertices;
     n_arcs_ = n_arcs;
     cuts_.assign(cuts.begin(), cuts.end());
     n_active_ = static_cast<int>(cuts_.size());
-    n_words_ = (n_active_ + 63) / 64;
 
     build_masks();
     precompute_betas();
   }
 
   int n_active() const { return n_active_; }
-  int n_words() const { return n_words_; }
-  bool has_cuts() const { return n_active_ > 0; }
-
-  /// Initialize R1C state (all zeros).
-  void init_state(std::span<uint64_t> state) const {
-    std::fill(state.begin(), state.end(), 0ULL);
-  }
-
-  /// Extend R1C state along arc (forward direction for 3-SRCs).
-  ///
-  /// For each cut ℓ:
-  ///   1. If arc ∉ AM_ℓ: reset bit to 0
-  ///   2. If target vertex ∈ C_ℓ: toggle bit (add 1/2)
-  ///   3. If bit overflows (1→0): apply cost -= β_ℓ
-  ///
-  /// Returns total cost delta from R1C contributions.
-  double extend(Direction /*dir*/, std::span<const uint64_t> in,
-                std::span<uint64_t> out, int arc_id, int target_vertex) const {
-    if (n_active_ == 0) return 0.0;
-
-    double cost_delta = 0.0;
-
-    for (int w = 0; w < n_words_; ++w) {
-      uint64_t s = in[w];
-
-      // Step 1: reset bits for cuts where arc ∉ AM
-      s &= arc_keep_mask_[arc_id][w];  // keep only cuts where arc ∈ AM
-
-      // Step 2 & 3: toggle bits for cuts where target vertex ∈ C
-      uint64_t toggle = vertex_toggle_mask_[target_vertex][w];
-      uint64_t overflow = s & toggle;  // bits that are 1 AND toggled → overflow
-      s ^= toggle;                     // toggle all relevant bits
-
-      // Cost from overflow: each overflowing cut contributes -β
-      if (overflow) {
-        cost_delta += compute_overflow_cost(w, overflow);
-      }
-
-      out[w] = s;
-    }
-
-    return cost_delta;
-  }
-
-  /// Extend R1C state along arc only (memory reset, no vertex toggle).
-  /// R1C equivalent of Resource::extend_along_arc for concatenation.
-  double extend_along_arc(std::span<const uint64_t> in,
-                          std::span<uint64_t> out, int arc_id) const {
-    if (n_active_ == 0) return 0.0;
-    for (int w = 0; w < n_words_; ++w) {
-      out[w] = in[w] & arc_keep_mask_[arc_id][w];
-    }
-    return 0.0;  // memory reset has no cost delta
-  }
-
-  /// Domination cost: extra cost L1 pays relative to L2 due to R1C states.
-  ///
-  /// For 3-SRC: if s1[ℓ]=1/2 and s2[ℓ]=0, then L1 has accumulated more
-  /// partial credit → could get a future cost reduction that L2 won't.
-  /// This means L1 is actually "better" for cut ℓ.
-  /// Conversely, if s1[ℓ]=0 and s2[ℓ]=1/2, L2 has the advantage.
-  ///
-  /// Returns: sum of β_ℓ for cuts where s2 has credit but s1 doesn't.
-  double domination_cost(Direction /*dir*/, int /*vertex*/,
-                         std::span<const uint64_t> s1,
-                         std::span<const uint64_t> s2) const {
-    if (n_active_ == 0) return 0.0;
-
-    double cost = 0.0;
-    for (int w = 0; w < n_words_; ++w) {
-      // Cuts where s2 has credit (1) but s1 doesn't (0)
-      uint64_t disadvantage = s2[w] & ~s1[w];
-      if (disadvantage) {
-        cost += compute_overflow_cost(w, disadvantage);
-      }
-    }
-    return cost;
-  }
-
-  /// Concatenation cost: when joining forward and backward labels.
-  ///
-  /// For 3-SRC: if both s_fw[ℓ]=1/2 and s_bw[ℓ]=1/2, total = 1 ≥ 1 → cost -β.
-  double concatenation_cost(Symmetry /*sym*/, int /*vertex*/,
-                            std::span<const uint64_t> s_fw,
-                            std::span<const uint64_t> s_bw) const {
-    if (n_active_ == 0) return 0.0;
-
-    double cost = 0.0;
-    for (int w = 0; w < n_words_; ++w) {
-      uint64_t both = s_fw[w] & s_bw[w];
-      if (both) {
-        cost += compute_overflow_cost(w, both);
-      }
-    }
-    return cost;
-  }
 
  private:
   void build_masks() {
-    // arc_keep_mask_[arc][word]: bits set for cuts where arc ∈ AM
-    // (i.e., we KEEP the state for those cuts; reset others)
-    arc_keep_mask_.assign(n_arcs_, std::vector<uint64_t>(n_words_, 0ULL));
-
-    // vertex_toggle_mask_[vertex][word]: bits set for cuts where vertex ∈ C
-    vertex_toggle_mask_.assign(n_vertices_,
-                               std::vector<uint64_t>(n_words_, 0ULL));
+    arc_keep_mask_.assign(n_arcs_, 0ULL);
+    vertex_toggle_mask_.assign(n_vertices_, 0ULL);
 
     for (int c = 0; c < n_active_; ++c) {
-      int w = c / 64;
-      uint64_t bit = 1ULL << (c % 64);
+      uint64_t bit = 1ULL << c;
 
-      // Memory arcs: set keep bit
       for (auto [from, to] : cuts_[c].memory_arcs) {
-        // We store arc as (from, to) pair — need arc index
-        // For now, memory_arcs stores arc indices directly
-        // Actually, the pair is the arc endpoints — we need to map
-        // This is a simplification: assume memory_arcs contains
-        // arc indices encoded in the .first field
         int arc_id = from;  // convention: first = arc_id
         if (arc_id >= 0 && arc_id < n_arcs_) {
-          arc_keep_mask_[arc_id][w] |= bit;
+          arc_keep_mask_[arc_id] |= bit;
         }
       }
 
-      // Base set vertices: set toggle bit
       for (int v : cuts_[c].base_set) {
         if (v >= 0 && v < n_vertices_) {
-          vertex_toggle_mask_[v][w] |= bit;
+          vertex_toggle_mask_[v] |= bit;
         }
       }
     }
   }
 
   void precompute_betas() {
-    // β_ℓ = -dual_value (dual_value is typically negative for active cuts)
     betas_.resize(n_active_);
     for (int c = 0; c < n_active_; ++c) {
       betas_[c] = -cuts_[c].dual_value;
     }
   }
 
-  /// Compute total cost for a bitmask of overflowing cuts in word w.
-  double compute_overflow_cost(int word, uint64_t mask) const {
+  double compute_overflow_cost(uint64_t mask) const {
     double cost = 0.0;
-    int base = word * 64;
     while (mask) {
       int bit = std::countr_zero(mask);
-      int cut_idx = base + bit;
-      if (cut_idx < n_active_) {
-        cost -= betas_[cut_idx];
+      if (bit < n_active_) {
+        cost -= betas_[bit];
       }
-      mask &= mask - 1;  // clear lowest set bit
+      mask &= mask - 1;
     }
     return cost;
   }
@@ -202,14 +141,14 @@ class R1CManager {
   int n_vertices_ = 0;
   int n_arcs_ = 0;
   int n_active_ = 0;
-  int n_words_ = 0;
 
   std::vector<R1Cut> cuts_;
   std::vector<double> betas_;
-
-  // Precomputed masks
-  std::vector<std::vector<uint64_t>> arc_keep_mask_;       // [arc_id][word]
-  std::vector<std::vector<uint64_t>> vertex_toggle_mask_;  // [vertex][word]
+  std::vector<uint64_t> arc_keep_mask_;       // [arc_id]
+  std::vector<uint64_t> vertex_toggle_mask_;  // [vertex]
 };
+
+/// Backward-compatible alias.
+using R1CManager = R1CResource;
 
 }  // namespace bgspprc

--- a/include/bgspprc/solver.h
+++ b/include/bgspprc/solver.h
@@ -1,12 +1,10 @@
 #pragma once
 
 #include <algorithm>
-#include <span>
 #include <vector>
 
 #include "bucket_graph.h"
 #include "problem_view.h"
-#include "r1c.h"
 #include "resource.h"
 #include "types.h"
 
@@ -81,8 +79,11 @@ class Solver {
   void reset_midpoint() { bg_.reset_midpoint(); }
   double midpoint() const { return bg_.midpoint(); }
 
-  /// Set R1C cuts.
-  void set_r1c_cuts(std::span<const R1Cut> cuts) { bg_.set_r1c_cuts(cuts); }
+  /// Access a resource in the pack (for runtime reconfiguration).
+  template <typename R>
+  R& resource() {
+    return bg_.template resource<R>();
+  }
 
   /// Whether the last enumeration was complete (no caps hit).
   bool enumeration_complete() const { return bg_.enumeration_complete(); }

--- a/tests/test_bucket_graph.cpp
+++ b/tests/test_bucket_graph.cpp
@@ -676,11 +676,11 @@ TEST_CASE("Bucket fixing: is_bucket_fixed query") {
   CHECK(bg.n_fixed_buckets() == 0);
 }
 
-// ── R1C engine ──
+// ── R1C Resource ──
 
 TEST_CASE("R1C: mask building and basic extend") {
   using namespace bgspprc;
-  R1CManager mgr;
+  R1CResource r1c;
 
   // Simple graph: 4 vertices, 4 arcs (0→1, 0→2, 1→3, 2→3)
   // One 3-SRC cut: C = {1, 2}, multiplier 1/2 each
@@ -692,36 +692,30 @@ TEST_CASE("R1C: mask building and basic extend") {
   cut.dual_value = -2.0;               // β = -(-2) = 2.0
 
   std::vector<R1Cut> cuts = {cut};
-  mgr.set_cuts(cuts, 4, 4);
+  r1c.set_cuts(cuts, 4, 4);
 
-  CHECK(mgr.n_active() == 1);
-  CHECK(mgr.n_words() == 1);
-  CHECK(mgr.has_cuts());
+  CHECK(r1c.n_active() == 1);
 
   // Init state: all zeros
-  uint64_t state[1] = {0};
-  mgr.init_state({state, 1});
-  CHECK(state[0] == 0ULL);
+  uint64_t state = r1c.init_state(Direction::Forward);
+  CHECK(state == 0ULL);
 
-  // Extend to vertex 1 (in C) via arc 0 (in AM)
-  // Keep mask keeps the bit (arc ∈ AM), toggle sets it (v1 ∈ C)
-  uint64_t out[1] = {0};
-  double cost1 = mgr.extend(Direction::Forward, {state, 1}, {out, 1}, 0, 1);
-  // State was 0, toggle → 1. No overflow (0→1). Cost delta = 0.
-  CHECK(cost1 == doctest::Approx(0.0));
-  CHECK(out[0] == 1ULL);  // bit 0 set (cut 0 has state 1/2)
+  // Extend along arc 0 (in AM) then to vertex 1 (in C)
+  auto [s_arc, c_arc] = r1c.extend_along_arc(Direction::Forward, state, 0);
+  auto [s1, c1] = r1c.extend_to_vertex(Direction::Forward, s_arc, 1);
+  CHECK(c_arc + c1 == doctest::Approx(0.0));
+  CHECK(s1 == 1ULL);  // bit 0 set (cut 0 has state 1/2)
 
-  // Extend to vertex 2 (in C) via arc 2 (NOT in AM)
-  // Keep mask resets bit (arc ∉ AM), then toggle
-  uint64_t out2[1] = {0};
-  double cost2 = mgr.extend(Direction::Forward, {out, 1}, {out2, 1}, 2, 2);
+  // Extend along arc 2 (NOT in AM) then to vertex 2 (in C)
+  auto [s_arc2, c_arc2] = r1c.extend_along_arc(Direction::Forward, s1, 2);
+  auto [s2, c2] = r1c.extend_to_vertex(Direction::Forward, s_arc2, 2);
   // State was 1, reset to 0 (arc 2 not in AM), toggle → 1. No overflow.
-  CHECK(out2[0] == 1ULL);
-  CHECK(cost2 == doctest::Approx(0.0));
+  CHECK(s2 == 1ULL);
+  CHECK(c_arc2 + c2 == doctest::Approx(0.0));
 }
 
 TEST_CASE("R1C: extend overflow applies cost") {
-  R1CManager mgr;
+  R1CResource r1c;
 
   // Cut with C = {1, 2}, AM = {arc 0, arc 2}
   R1Cut cut;
@@ -730,27 +724,23 @@ TEST_CASE("R1C: extend overflow applies cost") {
   cut.memory_arcs = {{0, 0}, {2, 0}};  // arc 0 and arc 2 in AM
   cut.dual_value = -3.0;               // β = 3.0
 
-  mgr.set_cuts({{cut}}, 4, 4);
+  r1c.set_cuts({{cut}}, 4, 4);
 
-  // Start with state = 0
-  uint64_t s0[1] = {0};
-
-  // Extend to v1 (in C) via arc 0 (in AM): 0 → toggle → 1
-  uint64_t s1[1] = {0};
-  double c1 = mgr.extend(Direction::Forward, {s0, 1}, {s1, 1}, 0, 1);
-  CHECK(s1[0] == 1ULL);
-  CHECK(c1 == doctest::Approx(0.0));
+  // Extend to v1 (in C) via arc 0 (in AM): 0 → keep → toggle → 1
+  auto [s_a0, ca0] = r1c.extend_along_arc(Direction::Forward, 0ULL, 0);
+  auto [s1, c1] = r1c.extend_to_vertex(Direction::Forward, s_a0, 1);
+  CHECK(s1 == 1ULL);
+  CHECK(ca0 + c1 == doctest::Approx(0.0));
 
   // Extend to v2 (in C) via arc 2 (in AM): 1 → keep(1) → toggle → overflow!
-  // Overflow: bit was 1, toggling to 0. Cost -= β = -3.0
-  uint64_t s2[1] = {0};
-  double c2 = mgr.extend(Direction::Forward, {s1, 1}, {s2, 1}, 2, 2);
-  CHECK(s2[0] == 0ULL);                // overflow resets to 0
-  CHECK(c2 == doctest::Approx(-3.0));  // -β applied
+  auto [s_a2, ca2] = r1c.extend_along_arc(Direction::Forward, s1, 2);
+  auto [s2, c2] = r1c.extend_to_vertex(Direction::Forward, s_a2, 2);
+  CHECK(s2 == 0ULL);                           // overflow resets to 0
+  CHECK(ca2 + c2 == doctest::Approx(-3.0));    // -β applied
 }
 
 TEST_CASE("R1C: domination cost") {
-  R1CManager mgr;
+  R1CResource r1c;
 
   R1Cut cut;
   cut.base_set = {1};
@@ -758,21 +748,19 @@ TEST_CASE("R1C: domination cost") {
   cut.memory_arcs = {{0, 0}};
   cut.dual_value = -4.0;  // β = 4.0
 
-  mgr.set_cuts({{cut}}, 3, 2);
+  r1c.set_cuts({{cut}}, 3, 2);
 
   // s1 has credit (1), s2 doesn't (0): s1 is better, no penalty
-  uint64_t s1[1] = {1ULL};
-  uint64_t s2[1] = {0ULL};
-  double dom = mgr.domination_cost(Direction::Forward, 1, {s1, 1}, {s2, 1});
+  double dom = r1c.domination_cost(Direction::Forward, 1, 1ULL, 0ULL);
   CHECK(dom == doctest::Approx(0.0));
 
   // s2 has credit (1), s1 doesn't (0): s1 is at disadvantage → penalty
-  double dom2 = mgr.domination_cost(Direction::Forward, 1, {s2, 1}, {s1, 1});
+  double dom2 = r1c.domination_cost(Direction::Forward, 1, 0ULL, 1ULL);
   CHECK(dom2 == doctest::Approx(-4.0));  // -β
 }
 
 TEST_CASE("R1C: concatenation cost") {
-  R1CManager mgr;
+  R1CResource r1c;
 
   R1Cut cut;
   cut.base_set = {1};
@@ -780,23 +768,19 @@ TEST_CASE("R1C: concatenation cost") {
   cut.memory_arcs = {{0, 0}};
   cut.dual_value = -5.0;  // β = 5.0
 
-  mgr.set_cuts({{cut}}, 3, 2);
+  r1c.set_cuts({{cut}}, 3, 2);
 
   // Both fw and bw have credit → cost -β
-  uint64_t fw[1] = {1ULL};
-  uint64_t bw[1] = {1ULL};
-  double c = mgr.concatenation_cost(Symmetry::Asymmetric, 1, {fw, 1}, {bw, 1});
+  double c = r1c.concatenation_cost(Symmetry::Asymmetric, 1, 1ULL, 1ULL);
   CHECK(c == doctest::Approx(-5.0));
 
   // Only one has credit → no cost
-  uint64_t zero[1] = {0ULL};
-  double c2 =
-      mgr.concatenation_cost(Symmetry::Asymmetric, 1, {fw, 1}, {zero, 1});
+  double c2 = r1c.concatenation_cost(Symmetry::Asymmetric, 1, 1ULL, 0ULL);
   CHECK(c2 == doctest::Approx(0.0));
 }
 
 TEST_CASE("R1C: extend_along_arc does memory reset without vertex toggle") {
-  R1CManager mgr;
+  R1CResource r1c;
 
   R1Cut cut;
   cut.base_set = {1};
@@ -804,25 +788,23 @@ TEST_CASE("R1C: extend_along_arc does memory reset without vertex toggle") {
   cut.memory_arcs = {{0, 0}};  // arc 0 is in AM
   cut.dual_value = -5.0;
 
-  mgr.set_cuts({{cut}}, 3, 2);
+  r1c.set_cuts({{cut}}, 3, 2);
 
-  uint64_t s[1] = {1ULL};  // bit set (visited vertex in C while in-memory)
+  uint64_t s = 1ULL;  // bit set (visited vertex in C while in-memory)
 
   // Arc 0 is in AM → bit should survive (no reset)
-  uint64_t out0[1] = {0};
-  double c0 = mgr.extend_along_arc({s, 1}, {out0, 1}, 0);
+  auto [out0, c0] = r1c.extend_along_arc(Direction::Forward, s, 0);
   CHECK(c0 == doctest::Approx(0.0));
-  CHECK(out0[0] == 1ULL);
+  CHECK(out0 == 1ULL);
 
   // Arc 1 is NOT in AM → bit should be cleared
-  uint64_t out1[1] = {0};
-  double c1 = mgr.extend_along_arc({s, 1}, {out1, 1}, 1);
+  auto [out1, c1] = r1c.extend_along_arc(Direction::Forward, s, 1);
   CHECK(c1 == doctest::Approx(0.0));
-  CHECK(out1[0] == 0ULL);
+  CHECK(out1 == 0ULL);
 }
 
 TEST_CASE("R1C: extend_along_arc clears concatenation overlap") {
-  R1CManager mgr;
+  R1CResource r1c;
 
   // Cut with C={1,2}, AM = {arc 0, arc 2}
   R1Cut cut;
@@ -831,30 +813,27 @@ TEST_CASE("R1C: extend_along_arc clears concatenation overlap") {
   cut.memory_arcs = {{0, 0}, {2, 0}};  // arcs 0 and 2 in AM
   cut.dual_value = -5.0;               // β = 5.0
 
-  mgr.set_cuts({{cut}}, 4, 4);
+  r1c.set_cuts({{cut}}, 4, 4);
 
-  uint64_t fw[1] = {1ULL};  // fw has bit set
-  uint64_t bw[1] = {1ULL};  // bw has bit set
+  uint64_t fw = 1ULL;  // fw has bit set
+  uint64_t bw = 1ULL;  // bw has bit set
 
   // Without extend_along_arc: s_fw & s_bw = 1 → -β = -5.0 (wrong if joining
   // arc not in AM)
-  double wrong =
-      mgr.concatenation_cost(Symmetry::Asymmetric, 1, {fw, 1}, {bw, 1});
+  double wrong = r1c.concatenation_cost(Symmetry::Asymmetric, 1, fw, bw);
   CHECK(wrong == doctest::Approx(-5.0));
 
   // Arc 1 is NOT in AM → memory reset clears fw bit
-  uint64_t ext[1] = {0};
-  mgr.extend_along_arc({fw, 1}, {ext, 1}, 1);
-  CHECK(ext[0] == 0ULL);
+  auto [ext, ce] = r1c.extend_along_arc(Direction::Forward, fw, 1);
+  CHECK(ext == 0ULL);
 
   // With extended state: s_ext & s_bw = 0 → 0 cost (correct)
-  double correct =
-      mgr.concatenation_cost(Symmetry::Asymmetric, 1, {ext, 1}, {bw, 1});
+  double correct = r1c.concatenation_cost(Symmetry::Asymmetric, 1, ext, bw);
   CHECK(correct == doctest::Approx(0.0));
 }
 
 TEST_CASE("R1C: extend_along_arc multiple cuts mixed memory") {
-  R1CManager mgr;
+  R1CResource r1c;
 
   // 3 cuts with different AM sets
   R1Cut cut0, cut1, cut2;
@@ -873,66 +852,62 @@ TEST_CASE("R1C: extend_along_arc multiple cuts mixed memory") {
   cut2.memory_arcs = {{2, 0}};  // arc 1 NOT in AM for cut2
   cut2.dual_value = -3.0;
 
-  mgr.set_cuts(std::vector<R1Cut>{cut0, cut1, cut2}, 4, 4);
+  r1c.set_cuts(std::vector<R1Cut>{cut0, cut1, cut2}, 4, 4);
 
   // All bits set
-  uint64_t fw[1] = {0b111ULL};
-  uint64_t bw[1] = {0b111ULL};
+  uint64_t fw = 0b111ULL;
+  uint64_t bw = 0b111ULL;
 
   // Extend along arc 1: only cut0 survives (arc 1 in AM for cut0 only)
-  uint64_t ext[1] = {0};
-  mgr.extend_along_arc({fw, 1}, {ext, 1}, 1);
-  CHECK((ext[0] & 1ULL) == 1ULL);  // cut0 survives
-  CHECK((ext[0] & 2ULL) == 0ULL);  // cut1 cleared
-  CHECK((ext[0] & 4ULL) == 0ULL);  // cut2 cleared
+  auto [ext, ce] = r1c.extend_along_arc(Direction::Forward, fw, 1);
+  CHECK((ext & 1ULL) == 1ULL);  // cut0 survives
+  CHECK((ext & 2ULL) == 0ULL);  // cut1 cleared
+  CHECK((ext & 4ULL) == 0ULL);  // cut2 cleared
 
   // Concatenation cost with extended state: only cut0 overlap → cost -= β₀ = -1.0
-  double c =
-      mgr.concatenation_cost(Symmetry::Asymmetric, 1, {ext, 1}, {bw, 1});
+  double c = r1c.concatenation_cost(Symmetry::Asymmetric, 1, ext, bw);
   CHECK(c == doctest::Approx(-1.0));  // only cut0's -β₀
 
   // Without fix (all bits): would be -1 + -2 + -3 = -6.0
-  double c_all =
-      mgr.concatenation_cost(Symmetry::Asymmetric, 1, {fw, 1}, {bw, 1});
+  double c_all = r1c.concatenation_cost(Symmetry::Asymmetric, 1, fw, bw);
   CHECK(c_all == doctest::Approx(-6.0));
 }
 
 TEST_CASE("R1C: bidir concatenation uses extended R1C state") {
   // End-to-end test: bidir solve with R1C should match mono solve.
   // Without the fix, bidir would report lower cost due to overcounted R1C.
+  using R1CPack = ResourcePack<R1CResource>;
   LargerGraph g;
 
   // LargerGraph: 6 vertices (0=src, 5=sink), 8 arcs
   // arcs: 0:(0,1) 1:(0,2) 2:(1,3) 3:(2,4) 4:(3,5) 5:(4,5) 6:(1,4) 7:(2,3)
 
   // Set up R1C cut where the bidir joining arc is NOT in AM.
-  // Cut C={3}, with AM = {arc 2:(1,3), arc 7:(2,3)} — arcs arriving at v3.
-  // The joining arc in bidir will likely be arc 4:(3,5) or arc 2:(1,3) etc.
-  // Key: if bidir joins on an arc NOT in AM, the fw R1C bit should be cleared.
   R1Cut cut;
   cut.base_set = {3};
   cut.multipliers = {0.5};
-  // Only arcs 2:(1,3) and 7:(2,3) are in AM — NOT arcs 4:(3,5) or 6:(1,4)
   cut.memory_arcs = {{2, 0}, {7, 0}};
-  cut.dual_value = -10.0;  // β = 10.0 — large enough to affect path ranking
+  cut.dual_value = -10.0;  // β = 10.0
 
   // Mono solve
-  BucketGraph<EmptyPack> bg_mono(
-      g.pv, EmptyPack{},
+  R1CResource r1c_mono;
+  BucketGraph<R1CPack> bg_mono(
+      g.pv, R1CPack{r1c_mono},
       {.bucket_steps = {5.0, 1.0}, .tolerance = 1e9});
+  bg_mono.resource<R1CResource>().set_cuts({{cut}}, g.pv.n_vertices, g.pv.n_arcs);
   bg_mono.build();
   bg_mono.set_stage(Stage::Exact);
-  bg_mono.set_r1c_cuts({{cut}});
   auto mono_paths = bg_mono.solve();
   REQUIRE(!mono_paths.empty());
 
   // Bidir solve
-  BucketGraph<EmptyPack> bg_bidir(
-      g.pv, EmptyPack{},
+  R1CResource r1c_bidir;
+  BucketGraph<R1CPack> bg_bidir(
+      g.pv, R1CPack{r1c_bidir},
       {.bucket_steps = {5.0, 1.0}, .tolerance = 1e9, .bidirectional = true});
+  bg_bidir.resource<R1CResource>().set_cuts({{cut}}, g.pv.n_vertices, g.pv.n_arcs);
   bg_bidir.build();
   bg_bidir.set_stage(Stage::Exact);
-  bg_bidir.set_r1c_cuts({{cut}});
   auto bidir_paths = bg_bidir.solve();
   REQUIRE(!bidir_paths.empty());
 
@@ -942,7 +917,7 @@ TEST_CASE("R1C: bidir concatenation uses extended R1C state") {
 }
 
 TEST_CASE("R1C: multiple cuts packed in one word") {
-  R1CManager mgr;
+  R1CResource r1c;
 
   // 3 cuts
   R1Cut cut0, cut1, cut2;
@@ -961,21 +936,19 @@ TEST_CASE("R1C: multiple cuts packed in one word") {
   cut2.memory_arcs = {{0, 0}, {1, 0}};
   cut2.dual_value = -3.0;
 
-  mgr.set_cuts(std::vector<R1Cut>{cut0, cut1, cut2}, 4, 4);
-  CHECK(mgr.n_active() == 3);
-  CHECK(mgr.n_words() == 1);
+  r1c.set_cuts(std::vector<R1Cut>{cut0, cut1, cut2}, 4, 4);
+  CHECK(r1c.n_active() == 3);
 
-  uint64_t s[1] = {0};
-  mgr.init_state({s, 1});
+  uint64_t s = r1c.init_state(Direction::Forward);
 
   // Extend to v1 via arc 0 (in AM for cut0 and cut2)
-  uint64_t s1[1] = {0};
-  mgr.extend(Direction::Forward, {s, 1}, {s1, 1}, 0, 1);
-  // cut0: toggle(v1∈C) → 1
-  // cut1: reset(arc0∉AM), toggle(v1∉C for cut1) → 0
+  auto [sa, ca] = r1c.extend_along_arc(Direction::Forward, s, 0);
+  auto [s1, c1] = r1c.extend_to_vertex(Direction::Forward, sa, 1);
+  // cut0: keep(arc0∈AM), toggle(v1∈C) → 1
+  // cut1: reset(arc0∉AM for cut1), toggle(v1∉C for cut1) → 0
   // cut2: keep(arc0∈AM), toggle(v1∈C) → 1
-  CHECK((s1[0] & 1ULL) == 1ULL);  // cut 0 = 1
-  CHECK((s1[0] & 4ULL) == 4ULL);  // cut 2 = 1
+  CHECK((s1 & 1ULL) == 1ULL);  // cut 0 = 1
+  CHECK((s1 & 4ULL) == 4ULL);  // cut 2 = 1
 }
 
 // ── SCC computation ──
@@ -1439,7 +1412,7 @@ TEST_CASE("Resource::symmetric() interface") {
 // ── LabelPool ──
 
 TEST_CASE("LabelPool: allocation and counting") {
-  LabelPool<EmptyPack> pool(0, 16);
+  LabelPool<EmptyPack> pool(16);
 
   CHECK(pool.count() == 0);
 
@@ -1456,26 +1429,16 @@ TEST_CASE("LabelPool: allocation and counting") {
   CHECK(pool.count() == 0);
 }
 
-TEST_CASE("LabelPool: R1C inline allocation") {
-  LabelPool<EmptyPack> pool(2, 16);  // 2 R1C words per label
+TEST_CASE("R1CResource: conforms to Resource concept") {
+  using namespace bgspprc;
+  static_assert(Resource<R1CResource>, "R1CResource must satisfy Resource");
 
-  auto* l = pool.allocate();
-  CHECK(l != nullptr);
-  CHECK(l->n_r1c_words == 2);
-  CHECK(l->r1c_states != nullptr);
-
-  // R1C states should be zeroed
-  CHECK(l->r1c_states[0] == 0ULL);
-  CHECK(l->r1c_states[1] == 0ULL);
-
-  // Write to R1C states (shouldn't crash)
-  l->r1c_states[0] = 0xDEADBEEFULL;
-  l->r1c_states[1] = 0xCAFEBABEULL;
-
-  // Allocate another — should not overlap
-  auto* l2 = pool.allocate();
-  CHECK(l2->r1c_states[0] == 0ULL);
-  CHECK(l2->r1c_states[1] == 0ULL);
+  // Verify it works in a ResourcePack
+  R1CResource r1c;
+  ResourcePack<R1CResource> pack(r1c);
+  CHECK(pack.symmetric());
+  auto states = pack.init_states(Direction::Forward);
+  CHECK(std::get<0>(states) == 0ULL);
 }
 
 // ── Warm starting (Phase 7) ──


### PR DESCRIPTION
## Summary
- Replaces `R1CManager` class with `R1CResource` struct that conforms to the `Resource` concept, using a single `uint64_t` state (max 64 active cuts)
- Removes all duplicate R1C handling from `bucket_graph.h` — extension, dominance, concatenation, init_state, warm labels, and theta-compatibility all go through the Pack dispatch uniformly
- Simplifies `Label` (no more `r1c_states` pointer/`n_r1c_words`) and `LabelPool` (no more inline R1C allocation or `set_r1c_words`)
- Removes `set_r1c_cuts()` from BucketGraph/Solver; callers now use `resource<R1CResource>().set_cuts(...)` with `BucketGraph<ResourcePack<R1CResource>>`
- Single-word masks (`vector<uint64_t>` instead of `vector<vector<uint64_t>>`) for cache efficiency
- `R1CManager` kept as a `using` alias for backward compatibility

**Net: -179 lines** (177 added, 356 removed)

## Test plan
- [x] All 184 unit tests pass (1196 assertions)
- [x] R1C unit tests updated to use new by-value `uint64_t` API
- [x] Bidir+R1C integration test uses `BucketGraph<ResourcePack<R1CResource>>`
- [x] Added static_assert test for `Resource<R1CResource>` concept conformance
- [x] CLI integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)