### PR TITLE
Remove arc_concatenation_cost from Resource interface

### DIFF
--- a/include/bgspprc/bucket_graph.h
+++ b/include/bgspprc/bucket_graph.h
@@ -1094,11 +1094,6 @@ class BucketGraph {
       if (ext_cost >= INF) return false;
       total_cost += ext_cost;
 
-      double acc = pack_.arc_concatenation_cost(
-          Symmetry::Asymmetric, arc_id, ext_states, bw->resource_states);
-      if (acc >= INF) return false;
-      total_cost += acc;
-
       double cc = pack_.concatenation_cost(Symmetry::Asymmetric, j, ext_states,
                                            bw->resource_states);
       if (cc >= INF) return false;
@@ -1710,11 +1705,6 @@ class BucketGraph {
                   Direction::Forward, fw->resource_states, a);
               if (ext_cost >= INF) continue;
               total_cost += ext_cost;
-
-              double acc = pack_.arc_concatenation_cost(sym, a, ext_states,
-                                                        bw->resource_states);
-              if (acc >= INF) continue;
-              total_cost += acc;
 
               double cc = pack_.concatenation_cost(sym, j, ext_states,
                                                    bw->resource_states);

--- a/include/bgspprc/r1c.h
+++ b/include/bgspprc/r1c.h
@@ -90,12 +90,6 @@ struct R1CResource {
     return 0.0;
   }
 
-  /// No arc-level concatenation cost for R1C.
-  double arc_concatenation_cost(Symmetry /*sym*/, int /*arc_id*/, State /*s_fw*/,
-                                State /*s_bw*/) const {
-    return 0.0;
-  }
-
  private:
   void build_masks() {
     arc_keep_mask_.assign(n_arcs_, 0ULL);

--- a/include/bgspprc/resource.h
+++ b/include/bgspprc/resource.h
@@ -8,7 +8,7 @@
 
 namespace bgspprc {
 
-/// Concept for a Meta-Solver resource type (§4.1 functions 1-7).
+/// Concept for a Meta-Solver resource type (§4.1 functions 1-5).
 ///
 /// Each resource carries per-label state and defines:
 ///  - symmetric: whether this resource supports symmetric labeling (§4.1)
@@ -16,8 +16,6 @@ namespace bgspprc {
 ///  - extend_to_vertex: how state changes at a vertex (destination marking)
 ///  - domination_cost: extra cost penalty when L1's state is "worse" than L2's
 ///  - concatenation_cost: cost adjustment when joining fw/bw labels at a vertex
-///  - arc_concatenation_cost: cost adjustment on the arc between extend and
-///  concat
 template <typename R>
 concept Resource =
     requires(const R& r, Direction dir, Symmetry sym, typename R::State s,
@@ -33,7 +31,6 @@ concept Resource =
       } -> std::same_as<std::pair<typename R::State, double>>;
       { r.domination_cost(dir, vertex, s, s2) } -> std::same_as<double>;
       { r.concatenation_cost(sym, vertex, s, s2) } -> std::same_as<double>;
-      { r.arc_concatenation_cost(sym, arc_id, s, s2) } -> std::same_as<double>;
     };
 
 /// Compile-time pack of resources. Labels carry a tuple of all states.
@@ -151,31 +148,6 @@ struct ResourcePack {
        ...);
     };
     do_cat(std::index_sequence_for<Rs...>{});
-    if (!feasible) return INF;
-    return total;
-  }
-
-  /// Compute arc-level concatenation cost (Meta-Solver 2026 §4.1 function 7).
-  /// If any resource returns INF, the concatenation is infeasible.
-  double arc_concatenation_cost(Symmetry sym, int arc_id,
-                                const StatesTuple& s_fw,
-                                const StatesTuple& s_bw) const {
-    double total = 0.0;
-    bool feasible = true;
-    auto do_acc = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
-      (([&] {
-         if (!feasible) return;
-         double c = std::get<Is>(resources).arc_concatenation_cost(
-             sym, arc_id, std::get<Is>(s_fw), std::get<Is>(s_bw));
-         if (c >= INF) {
-           feasible = false;
-           return;
-         }
-         total += c;
-       }()),
-       ...);
-    };
-    do_acc(std::index_sequence_for<Rs...>{});
     if (!feasible) return INF;
     return total;
   }

--- a/include/bgspprc/resources/cumulative_cost.h
+++ b/include/bgspprc/resources/cumulative_cost.h
@@ -79,11 +79,6 @@ struct CumulativeCostResource {
                             State s_bw) const {
     return s_fw.T_or_W * s_bw.T_or_W;
   }
-
-  double arc_concatenation_cost(Symmetry /*sym*/, int /*arc_id*/,
-                                State /*s_fw*/, State /*s_bw*/) const {
-    return 0.0;
-  }
 };
 
 }  // namespace bgspprc

--- a/include/bgspprc/resources/ng_path.h
+++ b/include/bgspprc/resources/ng_path.h
@@ -212,11 +212,6 @@ struct NgPathResource {
     if (s_fw & s_bw) return INF;
     return 0.0;
   }
-
-  double arc_concatenation_cost(Symmetry /*sym*/, int /*arc_id*/,
-                                State /*s_fw*/, State /*s_bw*/) const {
-    return 0.0;
-  }
 };
 
 }  // namespace bgspprc

--- a/include/bgspprc/resources/pickup_delivery.h
+++ b/include/bgspprc/resources/pickup_delivery.h
@@ -91,11 +91,6 @@ struct PickupDeliveryResource {
     if (s_bw.D > s_fw.D + EPS) return INF;
     return 0.0;
   }
-
-  double arc_concatenation_cost(Symmetry /*sym*/, int /*arc_id*/,
-                                State /*s_fw*/, State /*s_bw*/) const {
-    return 0.0;
-  }
 };
 
 }  // namespace bgspprc

--- a/include/bgspprc/resources/standard.h
+++ b/include/bgspprc/resources/standard.h
@@ -87,11 +87,6 @@ struct StandardResource {
                             State /*s_bw*/) const {
     return 0.0;
   }
-
-  double arc_concatenation_cost(Symmetry /*sym*/, int /*arc_id*/,
-                                State /*s_fw*/, State /*s_bw*/) const {
-    return 0.0;
-  }
 };
 
 }  // namespace bgspprc

--- a/tests/test_resource.cpp
+++ b/tests/test_resource.cpp
@@ -51,19 +51,6 @@ TEST_CASE("StandardResource extend_to_vertex is no-op") {
   CHECK(c == 0.0);
 }
 
-// ── arc_concatenation_cost ──
-
-TEST_CASE("StandardResource arc_concatenation_cost is no-op") {
-  double consumption[] = {1.0};
-  double lb[] = {0.0, 0.0};
-  double ub[] = {100.0, 100.0};
-
-  StandardResource res(consumption, lb, ub, 0, 1, 1);
-
-  CHECK(res.arc_concatenation_cost(Symmetry::Asymmetric, 0, 5.0, 10.0) == 0.0);
-  CHECK(res.arc_concatenation_cost(Symmetry::Symmetric, 0, 5.0, 10.0) == 0.0);
-}
-
 // ── ResourcePack ──
 
 TEST_CASE("EmptyPack operations") {
@@ -105,29 +92,6 @@ TEST_CASE("ResourcePack with StandardResource") {
   CHECK(pack.symmetric() == false);
 }
 
-TEST_CASE("ResourcePack arc_concatenation_cost composes correctly") {
-  double consumption[] = {2.0, 3.0};
-  double lb[] = {0.0, 0.0, 0.0};
-  double ub[] = {100.0, 100.0, 100.0};
-
-  auto pack =
-      make_resource_pack(StandardResource(consumption, lb, ub, 0, 2, 2));
-
-  auto s1 = pack.init_states(Direction::Forward);
-  auto s2 = pack.init_states(Direction::Backward);
-
-  CHECK(pack.arc_concatenation_cost(Symmetry::Asymmetric, 0, s1, s2) == 0.0);
-  CHECK(pack.arc_concatenation_cost(Symmetry::Symmetric, 1, s1, s2) == 0.0);
-}
-
-TEST_CASE("EmptyPack arc_concatenation_cost returns 0") {
-  EmptyPack pack;
-  auto states = pack.init_states(Direction::Forward);
-
-  CHECK(pack.arc_concatenation_cost(Symmetry::Asymmetric, 0, states, states) ==
-        0.0);
-}
-
 // ════════════════════════════════════════════════════════════════
 // NgPathResource — local bit mapping tests (DESTINATION MARKING)
 // ════════════════════════════════════════════════════════════════
@@ -155,14 +119,6 @@ static NgPathResource make_ng5() {
       {4, 3, 2},  // v4: {4, 3, 2}
   };
   return NgPathResource(5, 10, from, to, neighbors);
-}
-
-TEST_CASE("NgPathResource arc_concatenation_cost is no-op") {
-  auto ng = make_ng5();
-
-  CHECK(ng.arc_concatenation_cost(Symmetry::Asymmetric, 0, 0ULL, 0ULL) == 0.0);
-  CHECK(ng.arc_concatenation_cost(Symmetry::Symmetric, 0, 0b1111ULL,
-                                  0b1010ULL) == 0.0);
 }
 
 TEST_CASE("NgPathResource: bit_map assigns local positions") {
@@ -1501,15 +1457,6 @@ TEST_CASE("CumulativeCostResource: concatenation_cost") {
                                {0.0, 3.0}) == doctest::Approx(12.0));
   CHECK(res.concatenation_cost(Symmetry::Asymmetric, 0, {0.0, 0.0},
                                {0.0, 5.0}) == doctest::Approx(0.0));
-}
-
-TEST_CASE("CumulativeCostResource: arc_concatenation_cost is zero") {
-  double travel[] = {1.0};
-  double wt[] = {2.0};
-  CumulativeCostResource res(travel, wt, 10.0, 20.0, 1);
-
-  CHECK(res.arc_concatenation_cost(Symmetry::Asymmetric, 0, {5.0, 3.0},
-                                   {2.0, 1.0}) == 0.0);
 }
 
 TEST_CASE("ResourcePack<CumulativeCostResource> extend + domination") {


### PR DESCRIPTION
## Summary
- Remove `arc_concatenation_cost` — a dead 6th function not in the Meta-Solver 2026 paper (§4.1 defines 5 functions only)
- All 5 resource implementations returned `0.0`; the comment incorrectly attributed it to a nonexistent "§4.1 function 7"
- Arc-level cost adjustments are already handled by `extend_along_arc` which returns a cost delta

## Changes
- **resource.h**: Removed from `Resource` concept and `ResourcePack` (30 lines)
- **bucket_graph.h**: Removed 2 call sites in `is_theta_compatible` and `concatenate_and_extract` (10 lines)
- **5 resource files**: Removed stub methods (standard, ng_path, cumulative_cost, pickup_delivery, r1c)
- **test_resource.cpp**: Removed 5 test cases for the dead function (53 lines)

Total: 118 lines deleted, 1 insertion (comment fix `1-7` → `1-5`)

## Test plan
- [x] `cmake --build build` compiles cleanly
- [x] `ctest --test-dir build` — all tests pass
- [x] `grep -rn arc_concatenation_cost` confirms no source references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)