### PR TITLE
perf: lazy path extraction with partial sort

### DIFF
--- a/include/bgspprc/bucket_graph.h
+++ b/include/bgspprc/bucket_graph.h
@@ -831,7 +831,7 @@ class BucketGraph {
     // Cost pre-check: if L1->cost already exceeds L2->cost by more than the
     // maximum possible domination_cost reduction, L1 can never dominate.
     // Avoids expensive pack domination_cost() (ng bit ops, R1C state ops).
-    if (L1->cost > L2->cost + EPS + (-min_dom_cost_)) return false;
+    if (L1->cost > L2->cost + EPS - min_dom_cost_) return false;
 
     double dom_cost = L1->cost;
 
@@ -1849,15 +1849,9 @@ class BucketGraph {
                   INF);
     }
 
-    auto paths = extract_paths(fw_labels_);
-    std::sort(paths.begin(), paths.end(), [](const Path& a, const Path& b) {
-      return a.reduced_cost < b.reduced_cost;
-    });
-    if (opts_.max_paths > 0 && static_cast<int>(paths.size()) > opts_.max_paths) {
-      paths.resize(opts_.max_paths);
-      if (opts_.stage == Stage::Enumerate) enum_complete_ = false;
-    }
-    return paths;
+    std::vector<PathCandidate> candidates;
+    collect_sink_candidates(candidates, fw_labels_);
+    return select_and_realize(candidates);
   }
 
   // ── Bi-directional solve ──
@@ -1973,36 +1967,39 @@ class BucketGraph {
     if (opts_.stage == Stage::Exact && !opts_.symmetric) adjust_midpoint();
 
     // Collect paths: forward labels that reached sink + concatenations
-    auto paths = extract_paths(fw_labels_);
-    auto concat_paths = concatenate_and_extract();
-    paths.insert(paths.end(), concat_paths.begin(), concat_paths.end());
-
-    // Sort and limit
-    std::sort(paths.begin(), paths.end(), [](const Path& a, const Path& b) {
-      return a.reduced_cost < b.reduced_cost;
-    });
-    if (opts_.max_paths > 0 && static_cast<int>(paths.size()) > opts_.max_paths) {
-      paths.resize(opts_.max_paths);
-      if (opts_.stage == Stage::Enumerate) enum_complete_ = false;
-    }
-    return paths;
+    std::vector<PathCandidate> candidates;
+    collect_sink_candidates(candidates, fw_labels_);
+    collect_concat_candidates(candidates);
+    return select_and_realize(candidates);
   }
 
-  // ── Concatenation ──
+  // ── Candidate collection and path realization ──
 
-  std::vector<Path> concatenate_and_extract() {
-    std::vector<Path> paths;
+  // Lightweight proxy for a path: stores just enough to reconstruct later.
+  // Pointers into pool_ which is stable between collect and realize.
+  struct PathCandidate {
+    double reduced_cost;
+    double original_cost;
+    const Label<Pack>* fw_label;    // always set
+    const Label<Pack>* bw_label;    // null for sink paths
+    int concat_arc;                 // -1 for sink paths
+  };
 
+  void collect_sink_candidates(std::vector<PathCandidate>& candidates,
+                               const BucketLabels& bl) {
+    auto [start, end] = vertex_bucket_range(pv_.sink);
+    for (int bi = start; bi < end; ++bi) {
+      for (const auto* L : bl.labels[bi]) {
+        if (L->dominated) continue;
+        if (L->cost < opts_.theta) {
+          candidates.push_back({L->cost, L->real_cost, L, nullptr, -1});
+        }
+      }
+    }
+  }
+
+  void collect_concat_candidates(std::vector<PathCandidate>& candidates) {
     Symmetry sym = opts_.symmetric ? Symmetry::Symmetric : Symmetry::Asymmetric;
-
-    auto append_bw_subpath = [this](Path& p, const Label<Pack>* bw) {
-      scratch_path_verts_.clear();
-      scratch_path_arcs_.clear();
-      bw->get_backward_subpath(scratch_path_verts_, scratch_path_arcs_);
-      for (std::size_t k = 1; k < scratch_path_verts_.size(); ++k)
-        p.vertices.push_back(scratch_path_verts_[k]);
-      p.arcs.insert(p.arcs.end(), scratch_path_arcs_.begin(), scratch_path_arcs_.end());
-    };
 
     // Across-arc concatenation: for each arc a = (i,j), join fw labels at i
     // with bw labels at j using on-the-fly extend through arc a.
@@ -2082,18 +2079,7 @@ class BucketGraph {
                 }
 
                 if (total_cost < opts_.theta) {
-                  Path p;
-                  fw->get_path(p.vertices, p.arcs);
-                  p.arcs.push_back(a);
-                  p.vertices.push_back(j);
-                  if (opts_.symmetric) {
-                    append_symmetric_bw_subpath(p, bw);
-                  } else {
-                    append_bw_subpath(p, bw);
-                  }
-                  p.reduced_cost = total_cost;
-                  p.original_cost = total_real_cost;
-                  paths.push_back(std::move(p));
+                  candidates.push_back({total_cost, total_real_cost, fw, bw, a});
                 }
               }
             }
@@ -2101,30 +2087,50 @@ class BucketGraph {
         }
       }
     }();
-
-    return paths;
   }
 
-  // ── Path extraction ──
-
-  std::vector<Path> extract_paths(
-      const BucketLabels& bl) {
-    std::vector<Path> paths;
-
-    auto [start, end] = vertex_bucket_range(pv_.sink);
-    for (int bi = start; bi < end; ++bi) {
-      for (const auto* L : bl.labels[bi]) {
-        if (L->dominated) continue;
-        if (L->cost < opts_.theta) {
-          Path p;
-          L->get_path(p.vertices, p.arcs);
-          p.reduced_cost = L->cost;
-          p.original_cost = L->real_cost;
-          paths.push_back(std::move(p));
-        }
+  Path realize_path(const PathCandidate& c) {
+    Path p;
+    if (c.bw_label == nullptr) {
+      // Sink path — just walk the forward label's parent chain
+      c.fw_label->get_path(p.vertices, p.arcs);
+    } else {
+      // Concatenation path: fw subpath + arc + bw subpath
+      c.fw_label->get_path(p.vertices, p.arcs);
+      p.arcs.push_back(c.concat_arc);
+      int j = pv_.arc_to[c.concat_arc];
+      p.vertices.push_back(j);
+      if (opts_.symmetric) {
+        append_symmetric_bw_subpath(p, c.bw_label);
+      } else {
+        append_bw_subpath(p, c.bw_label);
       }
     }
+    p.reduced_cost = c.reduced_cost;
+    p.original_cost = c.original_cost;
+    return p;
+  }
 
+  std::vector<Path> select_and_realize(std::vector<PathCandidate>& candidates) {
+    auto cmp = [](const PathCandidate& a, const PathCandidate& b) {
+      return a.reduced_cost < b.reduced_cost;
+    };
+
+    int limit = static_cast<int>(candidates.size());
+    if (opts_.max_paths > 0 && limit > opts_.max_paths) {
+      limit = opts_.max_paths;
+      std::partial_sort(candidates.begin(), candidates.begin() + limit,
+                        candidates.end(), cmp);
+      candidates.resize(limit);
+      if (opts_.stage == Stage::Enumerate) enum_complete_ = false;
+    } else if (limit > 1) {
+      std::sort(candidates.begin(), candidates.end(), cmp);
+    }
+
+    std::vector<Path> paths;
+    paths.reserve(limit);
+    for (const auto& c : candidates)
+      paths.push_back(realize_path(c));
     return paths;
   }
 
@@ -2168,6 +2174,17 @@ class BucketGraph {
     auto it =
         arc_lookup_.find(static_cast<int64_t>(from) * pv_.n_vertices + to);
     return (it != arc_lookup_.end()) ? it->second : -1;
+  }
+
+  /// Append backward label's subpath (forward order, skipping first vertex
+  /// which is already in the path).
+  void append_bw_subpath(Path& p, const Label<Pack>* bw) {
+    scratch_path_verts_.clear();
+    scratch_path_arcs_.clear();
+    bw->get_backward_subpath(scratch_path_verts_, scratch_path_arcs_);
+    for (std::size_t k = 1; k < scratch_path_verts_.size(); ++k)
+      p.vertices.push_back(scratch_path_verts_[k]);
+    p.arcs.insert(p.arcs.end(), scratch_path_arcs_.begin(), scratch_path_arcs_.end());
   }
 
   /// Append the reversed forward path of a symmetric "bw" label.

--- a/tests/test_bucket_graph.cpp
+++ b/tests/test_bucket_graph.cpp
@@ -2337,3 +2337,270 @@ TEST_CASE("Backward exact completion bounds prune bw labels past midpoint") {
 }
 
 #endif  // !_WIN32
+
+// ── Lazy path extraction / partial_sort tests ──
+
+// Graph with multiple distinct-cost paths from source(0) to sink(4):
+//   0→1→3→4 cost=1+1+1=3
+//   0→1→4   cost=1+3=4
+//   0→2→3→4 cost=2+2+1=5
+//   0→2→4   cost=2+4=6
+struct MultiPathGraph {
+  int from[7] = {0, 0, 1, 2, 1, 2, 3};
+  int to[7] = {1, 2, 3, 3, 4, 4, 4};
+  double cost[7] = {1.0, 2.0, 1.0, 2.0, 3.0, 4.0, 1.0};
+  double time_d[7] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+  double tw_lb[5] = {0.0, 0.0, 0.0, 0.0, 0.0};
+  double tw_ub[5] = {10.0, 10.0, 10.0, 10.0, 10.0};
+
+  const double* arc_res[1] = {time_d};
+  const double* v_lb[1] = {tw_lb};
+  const double* v_ub[1] = {tw_ub};
+
+  ProblemView pv;
+
+  MultiPathGraph() {
+    pv.n_vertices = 5;
+    pv.source = 0;
+    pv.sink = 4;
+    pv.n_arcs = 7;
+    pv.arc_from = from;
+    pv.arc_to = to;
+    pv.arc_base_cost = cost;
+    pv.n_resources = 1;
+    pv.arc_resource = arc_res;
+    pv.vertex_lb = v_lb;
+    pv.vertex_ub = v_ub;
+    pv.n_main_resources = 1;
+  }
+};
+
+TEST_CASE("max_paths selects cheapest paths (mono, Exact)") {
+  // In Exact mode, max_paths is purely a post-labeling selection (no
+  // early-stop). This directly tests the partial_sort path in
+  // select_and_realize.
+  MultiPathGraph g;
+  using BG = BucketGraph<EmptyPack>;
+
+  // Exact with large theta finds all non-dominated paths
+  BG bg_all(g.pv, EmptyPack{},
+            {.bucket_steps = {5.0, 1.0},
+             .max_paths = 0,
+             .theta = 1e9,
+             .stage = Stage::Exact});
+  bg_all.build();
+  auto all = bg_all.solve();
+  REQUIRE(all.size() >= 2);
+  for (std::size_t i = 1; i < all.size(); ++i)
+    CHECK(all[i - 1].reduced_cost <= all[i].reduced_cost + 1e-9);
+
+  // Limit to 1 — cheapest only (exercises partial_sort branch)
+  BG bg_lim(g.pv, EmptyPack{},
+            {.bucket_steps = {5.0, 1.0},
+             .max_paths = 1,
+             .theta = 1e9,
+             .stage = Stage::Exact});
+  bg_lim.build();
+  auto limited = bg_lim.solve();
+  CHECK(limited.size() == 1);
+  CHECK(limited[0].reduced_cost == doctest::Approx(all[0].reduced_cost));
+}
+
+TEST_CASE("max_paths selects cheapest paths (bidir, Exact)") {
+  MultiPathGraph g;
+  using BG = BucketGraph<EmptyPack>;
+
+  BG bg_all(g.pv, EmptyPack{},
+            {.bucket_steps = {5.0, 1.0},
+             .max_paths = 0,
+             .theta = 1e9,
+             .bidirectional = true,
+             .stage = Stage::Exact});
+  bg_all.build();
+  auto all = bg_all.solve();
+  REQUIRE(all.size() >= 2);
+  for (std::size_t i = 1; i < all.size(); ++i)
+    CHECK(all[i - 1].reduced_cost <= all[i].reduced_cost + 1e-9);
+
+  // Limit to 1
+  BG bg_lim(g.pv, EmptyPack{},
+            {.bucket_steps = {5.0, 1.0},
+             .max_paths = 1,
+             .theta = 1e9,
+             .bidirectional = true,
+             .stage = Stage::Exact});
+  bg_lim.build();
+  auto limited = bg_lim.solve();
+  CHECK(limited.size() == 1);
+  CHECK(limited[0].reduced_cost == doctest::Approx(all[0].reduced_cost));
+  // Realized path must have valid structure
+  CHECK(limited[0].vertices.front() == 0);
+  CHECK(limited[0].vertices.back() == 4);
+  CHECK(limited[0].arcs.size() == limited[0].vertices.size() - 1);
+}
+
+TEST_CASE("max_paths preserves path contents") {
+  MultiPathGraph g;
+  using BG = BucketGraph<EmptyPack>;
+
+  // Exact mode: max_paths only affects extraction, not labeling
+  BG bg_all(g.pv, EmptyPack{},
+            {.bucket_steps = {5.0, 1.0},
+             .max_paths = 0,
+             .theta = 1e9,
+             .stage = Stage::Exact});
+  bg_all.build();
+  auto all = bg_all.solve();
+  REQUIRE(all.size() >= 2);
+
+  // Get limited paths — same solver, just fewer results
+  BG bg_lim(g.pv, EmptyPack{},
+            {.bucket_steps = {5.0, 1.0},
+             .max_paths = static_cast<int>(all.size()) - 1,
+             .theta = 1e9,
+             .stage = Stage::Exact});
+  bg_lim.build();
+  auto limited = bg_lim.solve();
+  REQUIRE(limited.size() == all.size() - 1);
+
+  // The realized paths should have identical vertices, arcs, and costs
+  for (std::size_t i = 0; i < limited.size(); ++i) {
+    CHECK(limited[i].vertices == all[i].vertices);
+    CHECK(limited[i].arcs == all[i].arcs);
+    CHECK(limited[i].reduced_cost == doctest::Approx(all[i].reduced_cost));
+    CHECK(limited[i].original_cost == doctest::Approx(all[i].original_cost));
+  }
+}
+
+TEST_CASE("max_paths=0 returns all paths sorted (Enumerate)") {
+  MultiPathGraph g;
+  using BG = BucketGraph<EmptyPack>;
+
+  BG bg(g.pv, EmptyPack{},
+        {.bucket_steps = {5.0, 1.0},
+         .max_paths = 0,
+         .theta = 1e9,
+         .stage = Stage::Enumerate});
+  bg.build();
+  auto paths = bg.solve();
+  REQUIRE(paths.size() == 4);  // 4 distinct paths in this graph
+  for (std::size_t i = 1; i < paths.size(); ++i)
+    CHECK(paths[i - 1].reduced_cost <= paths[i].reduced_cost + 1e-9);
+}
+
+TEST_CASE("max_paths >= n_paths returns all paths") {
+  MultiPathGraph g;
+  using BG = BucketGraph<EmptyPack>;
+
+  BG bg_all(g.pv, EmptyPack{},
+            {.bucket_steps = {5.0, 1.0},
+             .max_paths = 0,
+             .theta = 1e9,
+             .stage = Stage::Exact});
+  bg_all.build();
+  auto all = bg_all.solve();
+  int n = static_cast<int>(all.size());
+  REQUIRE(n >= 2);
+
+  // max_paths equal to total count — should return everything
+  BG bg_eq(g.pv, EmptyPack{},
+           {.bucket_steps = {5.0, 1.0},
+            .max_paths = n,
+            .theta = 1e9,
+            .stage = Stage::Exact});
+  bg_eq.build();
+  auto eq = bg_eq.solve();
+  CHECK(eq.size() == all.size());
+
+  // max_paths larger than total — same result
+  BG bg_big(g.pv, EmptyPack{},
+            {.bucket_steps = {5.0, 1.0},
+             .max_paths = n + 100,
+             .theta = 1e9,
+             .stage = Stage::Exact});
+  bg_big.build();
+  auto big = bg_big.solve();
+  CHECK(big.size() == all.size());
+}
+
+TEST_CASE("max_paths sets enum_complete_ false") {
+  ParallelArcGraph g;
+  using BG = BucketGraph<EmptyPack>;
+
+  // ParallelArcGraph has 2 paths in Enumerate mode (cost 3, 5)
+  BG bg(g.pv, EmptyPack{},
+        {.bucket_steps = {5.0, 1.0},
+         .max_paths = 1,
+         .theta = 1e9,
+         .stage = Stage::Enumerate});
+  bg.build();
+  auto paths = bg.solve();
+  CHECK(paths.size() == 1);
+  CHECK_FALSE(bg.enumeration_complete());
+}
+
+TEST_CASE("Bidir concatenation paths are realized correctly") {
+  ParallelArcGraph g;
+  using BG = BucketGraph<EmptyPack>;
+
+  BG bg(g.pv, EmptyPack{},
+        {.bucket_steps = {5.0, 1.0},
+         .max_paths = 0,
+         .theta = 1e9,
+         .bidirectional = true,
+         .stage = Stage::Exact});
+  bg.build();
+  auto paths = bg.solve();
+  REQUIRE(!paths.empty());
+
+  // All paths must start at source and end at sink with valid structure
+  for (const auto& p : paths) {
+    REQUIRE(!p.vertices.empty());
+    CHECK(p.vertices.front() == 0);
+    CHECK(p.vertices.back() == 3);
+    CHECK(p.arcs.size() == p.vertices.size() - 1);
+    // Verify arc connectivity
+    for (std::size_t k = 0; k < p.arcs.size(); ++k) {
+      CHECK(g.from[p.arcs[k]] == p.vertices[k]);
+      CHECK(g.to[p.arcs[k]] == p.vertices[k + 1]);
+    }
+  }
+  // Sorted by cost
+  for (std::size_t i = 1; i < paths.size(); ++i)
+    CHECK(paths[i - 1].reduced_cost <= paths[i].reduced_cost + 1e-9);
+}
+
+TEST_CASE("Bidir max_paths realizes concatenation paths correctly") {
+  MultiPathGraph g;
+  using BG = BucketGraph<EmptyPack>;
+
+  // Get all bidir paths
+  BG bg_all(g.pv, EmptyPack{},
+            {.bucket_steps = {5.0, 1.0},
+             .max_paths = 0,
+             .theta = 1e9,
+             .bidirectional = true,
+             .stage = Stage::Exact});
+  bg_all.build();
+  auto all = bg_all.solve();
+  REQUIRE(all.size() >= 2);
+
+  // Get limited — exercises realize_path for concatenation candidates
+  BG bg_lim(g.pv, EmptyPack{},
+            {.bucket_steps = {5.0, 1.0},
+             .max_paths = 1,
+             .theta = 1e9,
+             .bidirectional = true,
+             .stage = Stage::Exact});
+  bg_lim.build();
+  auto limited = bg_lim.solve();
+  REQUIRE(limited.size() == 1);
+  CHECK(limited[0].reduced_cost == doctest::Approx(all[0].reduced_cost));
+
+  // Verify arc connectivity of realized path
+  for (std::size_t k = 0; k < limited[0].arcs.size(); ++k) {
+    CHECK(g.from[limited[0].arcs[k]] == limited[0].vertices[k]);
+    CHECK(g.to[limited[0].arcs[k]] == limited[0].vertices[k + 1]);
+  }
+}


### PR DESCRIPTION
## Summary

- Replace eager `get_path()` + full `sort` + truncate with lightweight `PathCandidate` collection, `partial_sort` for top-K, then `realize_path()` only for survivors
- Avoids wasted parent-chain walks and vector allocations for paths discarded by `max_paths`
- Extract `append_bw_subpath` and `collect_sink_candidates` as reusable helpers

## Test plan

- [x] All 187 unit tests pass (`build/test_runner`)
- [x] 8 new tests covering:
  - `partial_sort` top-K selection (mono + bidir, Exact mode)
  - Path content fidelity (vertices, arcs, costs match unlimited solve)
  - Enumerate mode produces all paths sorted
  - `max_paths >= n_paths` returns everything
  - `enum_complete_` flag set on truncation
  - Bidir concatenation path structure and arc connectivity
- [x] `ctest --test-dir build` all 3 test suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)