### PR TITLE
Drop redundant __AVX2__ guard for SIMD

### DIFF
--- a/include/bgspprc/bucket_graph.h
+++ b/include/bgspprc/bucket_graph.h
@@ -15,7 +15,7 @@
 #include <unordered_map>
 #include <vector>
 
-#if defined(__AVX2__) && __has_include(<experimental/simd>)
+#if __has_include(<experimental/simd>)
 #include <experimental/simd>
 #define BGSPPRC_HAS_SIMD 1
 #endif


### PR DESCRIPTION
## Summary
- Remove `__AVX2__` from the SIMD preprocessor guard, keeping only the `__has_include(<experimental/simd>)` check
- `native_simd` automatically uses the best ISA for the compilation target (SSE2 by default, AVX2 with `-march=native` or `-mavx2`)
- The old guard was redundant (CMakeLists.txt already adds `-march=native`) and would block even SSE2 fallback without it

## Test plan
- [x] Default build produces AVX2 instructions (1554 confirmed via objdump)
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)