### PR TITLE
Fix StandardResource backward extension and vertex bound checks

### DIFF
--- a/include/bgspprc/resources/standard.h
+++ b/include/bgspprc/resources/standard.h
@@ -48,7 +48,7 @@ struct StandardResource {
 
   State init_state(Direction dir) const {
     if (dir == Direction::Forward) return lb[source];
-    return lb[sink];  // backward starts from sink lower bound
+    return ub[sink];  // backward starts from sink upper bound (Meta-Solver §4.2.1)
   }
 
   /// Extend along arc. Returns (new_state, cost_delta).
@@ -59,23 +59,26 @@ struct StandardResource {
     // we do the same extension as main resources.
     double d = consumption[arc_id];
     if (dir == Direction::Forward) {
-      // Not available from arc arrays here, so we assume arc_to is
-      // handled by the caller. For non-main resources, we track state
-      // but vertex bounds are checked by the caller during extend.
-      double q_new = q + d;
-      // We can't check vertex bounds without knowing the target vertex.
-      // This is returned to the caller who checks bounds.
-      return {q_new, 0.0};
+      return {q + d, 0.0};
     } else {
-      double q_new = q + d;
-      return {q_new, 0.0};
+      return {q - d, 0.0};
     }
   }
 
-  /// Extend to vertex: no-op for standard resource.
-  std::pair<State, double> extend_to_vertex(Direction /*dir*/, State q,
-                                            int /*vertex*/) const {
-    return {q, 0.0};
+  /// Extend to vertex: clamp to vertex bounds and check feasibility.
+  /// Forward: q = max(q, lb[v]), infeasible if q > ub[v].
+  /// Backward: q = min(q, ub[v]), infeasible if q < lb[v].
+  std::pair<State, double> extend_to_vertex(Direction dir, State q,
+                                            int vertex) const {
+    if (dir == Direction::Forward) {
+      double q_new = std::max(q, lb[vertex]);
+      if (q_new > ub[vertex]) return {q_new, INF};
+      return {q_new, 0.0};
+    } else {
+      double q_new = std::min(q, ub[vertex]);
+      if (q_new < lb[vertex]) return {q_new, INF};
+      return {q_new, 0.0};
+    }
   }
 
   double domination_cost(Direction /*dir*/, int /*vertex*/, State /*s1*/,

--- a/tests/test_resource.cpp
+++ b/tests/test_resource.cpp
@@ -20,7 +20,7 @@ TEST_CASE("StandardResource init_state forward") {
   StandardResource res(consumption, lb, ub, 0, 2, 3);
 
   CHECK(res.init_state(Direction::Forward) == 0.0);    // lb[source]
-  CHECK(res.init_state(Direction::Backward) == 10.0);  // lb[sink]
+  CHECK(res.init_state(Direction::Backward) == 30.0);  // ub[sink]
 }
 
 TEST_CASE("StandardResource extend") {
@@ -39,16 +39,65 @@ TEST_CASE("StandardResource extend") {
   CHECK(c2 == 0.0);
 }
 
-TEST_CASE("StandardResource extend_to_vertex is no-op") {
+TEST_CASE("StandardResource extend backward") {
+  double consumption[] = {5.0, 3.0};
+  double lb[] = {0.0, 0.0, 0.0};
+  double ub[] = {100.0, 100.0, 100.0};
+
+  StandardResource res(consumption, lb, ub, 0, 2, 2);
+
+  // Backward extension subtracts consumption
+  auto [s1, c1] = res.extend_along_arc(Direction::Backward, 50.0, 0);
+  CHECK(s1 == 45.0);
+  CHECK(c1 == 0.0);
+
+  auto [s2, c2] = res.extend_along_arc(Direction::Backward, 50.0, 1);
+  CHECK(s2 == 47.0);
+  CHECK(c2 == 0.0);
+}
+
+TEST_CASE("StandardResource extend_to_vertex forward") {
   double consumption[] = {5.0};
-  double lb[] = {0.0, 0.0};
-  double ub[] = {100.0, 100.0};
+  double lb[] = {0.0, 10.0};
+  double ub[] = {100.0, 50.0};
 
   StandardResource res(consumption, lb, ub, 0, 1, 1);
 
-  auto [s, c] = res.extend_to_vertex(Direction::Forward, 42.0, 1);
-  CHECK(s == 42.0);
-  CHECK(c == 0.0);
+  // Within bounds, no clamping needed
+  auto [s1, c1] = res.extend_to_vertex(Direction::Forward, 25.0, 1);
+  CHECK(s1 == 25.0);
+  CHECK(c1 == 0.0);
+
+  // Below lb → clamp up
+  auto [s2, c2] = res.extend_to_vertex(Direction::Forward, 5.0, 1);
+  CHECK(s2 == 10.0);
+  CHECK(c2 == 0.0);
+
+  // Above ub → infeasible
+  auto [s3, c3] = res.extend_to_vertex(Direction::Forward, 60.0, 1);
+  CHECK(c3 >= INF);
+}
+
+TEST_CASE("StandardResource extend_to_vertex backward") {
+  double consumption[] = {5.0};
+  double lb[] = {0.0, 10.0};
+  double ub[] = {100.0, 50.0};
+
+  StandardResource res(consumption, lb, ub, 0, 1, 1);
+
+  // Within bounds, no clamping needed
+  auto [s1, c1] = res.extend_to_vertex(Direction::Backward, 25.0, 1);
+  CHECK(s1 == 25.0);
+  CHECK(c1 == 0.0);
+
+  // Above ub → clamp down
+  auto [s2, c2] = res.extend_to_vertex(Direction::Backward, 60.0, 1);
+  CHECK(s2 == 50.0);
+  CHECK(c2 == 0.0);
+
+  // Below lb → infeasible
+  auto [s3, c3] = res.extend_to_vertex(Direction::Backward, 5.0, 1);
+  CHECK(c3 >= INF);
 }
 
 // ── ResourcePack ──
@@ -85,7 +134,7 @@ TEST_CASE("ResourcePack with StandardResource") {
 
   auto [vtx_states, vtx_cost] =
       pack.extend_to_vertex(Direction::Forward, new_states, 1);
-  CHECK(std::get<0>(vtx_states) == 2.0);  // no-op
+  CHECK(std::get<0>(vtx_states) == 2.0);  // within bounds, no clamp
   CHECK(vtx_cost == 0.0);
 
   // StandardResource is conservatively non-symmetric


### PR DESCRIPTION
## Summary
- **`init_state` backward**: returned `lb[sink]` instead of `ub[sink]` (Meta-Solver §4.2.1 specifies backward init → upper bound)
- **`extend_along_arc` backward**: added consumption (`q + d`) instead of subtracting (`q - d`)
- **`extend_to_vertex`**: was a no-op — now clamps to vertex bounds and returns INF for infeasible extensions, matching `bucket_graph.h:817-822`

These bugs would cause incorrect results if `StandardResource` is used as a non-main resource in backward or bidirectional solves.

## Test plan
- [x] Updated existing `init_state` test for corrected backward value
- [x] Added `StandardResource extend backward` test (subtraction)
- [x] Added `extend_to_vertex forward` test (clamp up, within bounds, infeasible)
- [x] Added `extend_to_vertex backward` test (clamp down, within bounds, infeasible)
- [x] All 3 test suites pass (unit_tests, cli_unit_tests, cli_integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)