### PR TITLE
Heuristic1: 1 label per bucket (BG2021 §5)

### DIFF
--- a/include/bgspprc/bucket_graph.h
+++ b/include/bgspprc/bucket_graph.h
@@ -1125,6 +1125,34 @@ class BucketGraph {
       return true;
     }
 
+    // BG2021 §5 Stage 1: keep only the cheapest label per bucket.
+    if (opts_.stage == Stage::Heuristic1) {
+      auto& bucket = bl.labels[actual_bi];
+      if (bucket.empty()) {
+        insert_sorted(bl, actual_bi, new_label);
+        ++label_count;
+        if (dir == Direction::Forward)
+          ++fw_label_count_;
+        else
+          ++bw_label_count_;
+        return true;
+      }
+      // Bucket has exactly 1 label. Replace if new is cheaper.
+      auto* existing = bucket[0];
+      if (new_label->cost < existing->cost - EPS) {
+        existing->dominated = true;
+        bucket[0] = new_label;
+        bl.costs[actual_bi][0] = new_label->cost;
+        bl.q0[actual_bi][0] = new_label->q[0];
+        bl.q1[actual_bi][0] = new_label->q[1];
+        if constexpr (has_ng_) {
+          bl.ng_bits[actual_bi][0] = label_ng_bits(new_label);
+        }
+        return true;
+      }
+      return false;
+    }
+
     // Normal: dominance check
     if (!dominated_in_bucket(new_label, actual_bi, dir, bl)) {
       remove_dominated(new_label, actual_bi, dir, bl);
@@ -2448,6 +2476,7 @@ class BucketGraph {
   }
 
   void inject_warm_labels(BucketLabels& bl, Direction dir) {
+    int label_count = 0;  // local counter for try_insert_label
     for (const auto& wl : warm_labels_) {
       if (wl.dir != dir) continue;
 
@@ -2466,9 +2495,7 @@ class BucketGraph {
       int bi = vertex_bucket_index(wl.vertex, wl.q);
       L->bucket = bi;
 
-      if (!dominated_in_bucket(L, bi, dir, bl)) {
-        insert_sorted(bl, bi, L);
-      }
+      try_insert_label(L, bi, dir, bl, label_count);
     }
   }
 

--- a/tests/test_bucket_graph.cpp
+++ b/tests/test_bucket_graph.cpp
@@ -513,9 +513,9 @@ TEST_CASE("Stage: Heuristic1 cost-only dominance") {
   REQUIRE(!exact_paths.empty());
   REQUIRE(!h1_paths.empty());
 
-  // Heuristic1 should find at least as good cost (more aggressive dominance
-  // means fewer labels but shouldn't miss the optimal on EmptyPack)
-  CHECK(h1_paths[0].reduced_cost <= exact_paths[0].reduced_cost + 1e-6);
+  // BG2021 §5: Heuristic1 keeps 1 label per bucket — a true heuristic
+  // that may miss the optimal. Cost should be >= exact (or equal).
+  CHECK(h1_paths[0].reduced_cost >= exact_paths[0].reduced_cost - 1e-6);
 }
 
 TEST_CASE("Stage: set_stage changes behavior") {
@@ -534,8 +534,36 @@ TEST_CASE("Stage: set_stage changes behavior") {
   REQUIRE(!h1_paths.empty());
   REQUIRE(!exact_paths.empty());
 
-  CHECK(h1_paths[0].reduced_cost ==
-        doctest::Approx(exact_paths[0].reduced_cost));
+  // H1 is a heuristic (1 label/bucket), so cost >= exact is expected.
+  // After set_stage(Exact), we get the true optimum.
+  CHECK(h1_paths[0].reduced_cost >= exact_paths[0].reduced_cost - 1e-6);
+}
+
+TEST_CASE("Heuristic1: 1 label per bucket keeps only cheapest") {
+  LargerGraph g;
+
+  // Small bucket steps so multiple labels compete for the same bucket.
+  BucketGraph<EmptyPack> h1(g.pv, EmptyPack{},
+                            {.bucket_steps = {2.0, 1.0},
+                             .theta = 1e9,
+                             .stage = Stage::Heuristic1});
+  h1.build();
+  auto h1_paths = h1.solve();
+
+  BucketGraph<EmptyPack> exact(
+      g.pv, EmptyPack{},
+      {.bucket_steps = {2.0, 1.0}, .theta = 1e9, .stage = Stage::Exact});
+  exact.build();
+  auto exact_paths = exact.solve();
+
+  REQUIRE(!exact_paths.empty());
+  REQUIRE(!h1_paths.empty());
+
+  // H1 finds valid paths but cost >= exact (1 label/bucket is lossy).
+  CHECK(h1_paths[0].reduced_cost >= exact_paths[0].reduced_cost - 1e-6);
+
+  // H1 should produce fewer or equal paths (aggressive pruning).
+  CHECK(h1_paths.size() <= exact_paths.size());
 }
 
 // ── Bidirectional arc elimination ──

--- a/tests/test_small_instance.cpp
+++ b/tests/test_small_instance.cpp
@@ -138,6 +138,7 @@ TEST_CASE("End-to-end: tight time windows") {
 
   Solver<EmptyPack> solver(pv, EmptyPack{},
                            {.bucket_steps = {5.0, 1.0}, .theta = 1e9});
+  solver.set_stage(Stage::Exact);
   solver.build();
 
   auto paths = solver.solve();
@@ -283,6 +284,7 @@ TEST_CASE("Bidirectional: tight time windows") {
   // Mono
   Solver<EmptyPack> mono(pv, EmptyPack{},
                          {.bucket_steps = {5.0, 1.0}, .theta = 1e9});
+  mono.set_stage(Stage::Exact);
   mono.build();
   auto mono_paths = mono.solve();
 
@@ -290,6 +292,7 @@ TEST_CASE("Bidirectional: tight time windows") {
   Solver<EmptyPack> bidir(
       pv, EmptyPack{},
       {.bucket_steps = {5.0, 1.0}, .bidirectional = true, .theta = 1e9});
+  bidir.set_stage(Stage::Exact);
   bidir.build();
   auto bidir_paths = bidir.solve();
 


### PR DESCRIPTION
## Summary

- **Heuristic1 now keeps only the cheapest label per bucket**, matching BG2021 §5 Stage 1 ("light" pricing heuristic). Previously H1 was identical to H2 — both ignored ng/R1C in dominance but kept all non-dominated labels.
- **Warm label injection routed through `try_insert_label`** so the 1-label-per-bucket invariant holds during warm starting.
- **Test fixes**: tight-time-window Solver tests now use `Stage::Exact` (they validate exact correctness, not heuristic behavior). H1 cost checks flipped to `>=` since H1 is now a true heuristic.

## Paper correspondence

| Paper (BG2021 §5) | Our Stage | What it does | Status |
|---|---|---|---|
| Stage 1 "light" | `Heuristic1` | 1 label/bucket + ignore F/S in dominance | ✅ Fixed |
| Stage 2 | `Heuristic2` | Ignore F/S in dominance, keep all non-dom | ✅ Already matched |
| Stage 3 "exact" | `Exact` | Full exact labeling | ✅ Already matched |

## Test plan

- [x] All 190 unit tests pass
- [x] New test: "Heuristic1: 1 label per bucket keeps only cheapest" on LargerGraph
- [x] Verified H1 produces fewer paths than Exact (1 vs 2 on LargerGraph)

🤖 Generated with [Claude Code](https://claude.com/claude-code)